### PR TITLE
Update the hoprd operator container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git/
+.github/
+charts/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -381,7 +381,7 @@ dependencies = [
 
 [[package]]
 name = "hopr_operator"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "futures",
  "k8s-openapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,11 @@ serde = "1.0"
 serde_json = "1.0"
 schemars = "0.8"
 thiserror = "1.0"
+# Add openssl-sys as a direct dependency so it can be cross compiled to
+# x86_64-unknown-linux-musl using the "vendored" feature below
+openssl-sys = "*"
+
+[features]
+# Force openssl-sys to staticly link in the openssl library. Necessary when
+# cross compiling to x86_64-unknown-linux-musl.
+vendored = ["openssl-sys/vendored"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr_operator"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2021"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,32 +1,34 @@
 ARG RUST_IMAGE=${RUST_IMAGE:-rust:1.67}
 
-FROM ${RUST_IMAGE} as build
+FROM ${RUST_IMAGE} as builder
 
-# shell project to cache dependencies
-RUN USER=root cargo new --bin hopr_operator
+# musl toolchain for static binaries
+RUN apt update && apt install -y pkg-config libssl-dev musl-tools
+ENV SYSROOT=/dummy
+ENV OPENSSL_STATIC=1
+ENV OPENSSL_INCLUDE_DIR=/usr/include/openssl
+
+# build project sources
+RUN mkdir -p /hopr_operator
 WORKDIR /hopr_operator
 
 COPY ./Cargo.lock ./Cargo.lock
 COPY ./Cargo.toml ./Cargo.toml
-
-RUN cargo build --release
-RUN rm src/*.rs
-
-# build project sources
 COPY ./src ./src
 
-RUN rm ./target/release/deps/hopr_operator*
-RUN cargo build --release
+RUN rustup target install --toolchain $(rustup toolchain list | head -n 1 | awk '{print $1}') $(uname -m)-unknown-linux-musl
+RUN OPENSSL_LIB_DIR=/usr/lib/$(uname -m)-linux-gnu RUSTFLAGS="-C target-feature=+crt-static" cargo build --release --target $(uname -m)-unknown-linux-musl --features vendored
+RUN mv target/$(uname -m)-unknown-linux-musl/release/hopr_operator target/
 
-FROM debian:11.6-slim
+
+
+FROM scratch
+
 LABEL name="hoprd operator" \
       maintainer="tech@hoprnet.org" \
       vendor="HOPR" \
       summary="Operator managing hoprd instances" \
       description="Automation to introduce a hoprd network into a Kubernetes cluster using a dedicated operator"
-COPY --from=build /hopr_operator/target/release/hopr_operator /bin/hopr_operator
+COPY --from=builder /hopr_operator/target/hopr_operator /bin/hopr_operator
 
 ENTRYPOINT ["/bin/hopr_operator"]
-
-# Build Image command
-# docker build -t gcr.io/hoprassociation/hopr-operator:latest .

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY ./Cargo.lock ./Cargo.lock
 COPY ./Cargo.toml ./Cargo.toml
 COPY ./src ./src
 
-RUN rustup target install --toolchain $(rustup toolchain list | head -n 1 | awk '{print $1}') $(uname -m)-unknown-linux-musl
+RUN rustup target install $(uname -m)-unknown-linux-musl
 RUN OPENSSL_LIB_DIR=/usr/lib/$(uname -m)-linux-gnu RUSTFLAGS="-C target-feature=+crt-static" cargo build --release --target $(uname -m)-unknown-linux-musl --features vendored
 RUN mv target/$(uname -m)-unknown-linux-musl/release/hopr_operator target/
 

--- a/README.md
+++ b/README.md
@@ -8,4 +8,11 @@ A Kubernetes operator built on top of [kube-rs](https://github.com/clux/kube-rs)
 2. Build the project with `cargo build`. If the build fails, make sure `libssl-dev` is available.
 3. Run the operator using `cargo run`. It will run outside of the Kubernetes cluster and connect to the Kubernetes REST API using the account inside the `KUBECONFIG` automatically.
 
-Finally, a custom `Hoprd` resource can be created with `kubectl apply -f hoprd-node-1.yaml`. A new deployment with `Hoprd` node will be created. 
+Finally, a custom `Hoprd` resource can be created with `kubectl apply -f hoprd-node-1.yaml`. A new deployment with `Hoprd` node will be created.
+
+## Container
+Build the hoprd-operator container using in the repo root:
+
+```shell
+docker build -t gcr.io/hoprassociation/hopr-operator:latest .
+```

--- a/charts/hoprd-operator/Chart.yaml
+++ b/charts/hoprd-operator/Chart.yaml
@@ -1,8 +1,8 @@
+---
+
 apiVersion: v2
 name: hopr-operator
+version: 0.1.3
 description: A Helm chart operator for managing Hopr nodes
 type: application
 icon: "https://hoprnet.org/assets/icons/logo.svg"
-# This is the chart version. This version number should be incremented each time you make changes
-# to the chart and its templates, including the app version.
-version: 0.1.2

--- a/charts/hoprd-operator/README.md
+++ b/charts/hoprd-operator/README.md
@@ -49,8 +49,8 @@ Chart version `Chart.yaml` should be increased according to [semver](http://semv
 | `affinity`           | Affinity specifications                                                                                          | `{}`                            |
 | `image.registry`     | Docker registry                                                                                                  | `gcr.io`                        |
 | `image.repository`   | Docker image repository                                                                                          | `hoprassociation/hopr-operator` |
-| `image.tag`          | Docker image tag                                                                                                 | `latest`                        |
-| `image.pullPolicy`   | Pull policy as deinfed in                                                                                        | `Always`                        |
+| `image.tag`          | Docker image tag                                                                                                 | `0.1.3`                         |
+| `image.pullPolicy`   | Pull policy as deinfed in                                                                                        | `IfNotPresent`                  |
 | `service.ports.name` | Name of the API service port                                                                                     | `api`                           |
 
 ### Metrics parameters

--- a/charts/hoprd-operator/values.yaml
+++ b/charts/hoprd-operator/values.yaml
@@ -66,15 +66,15 @@ image:
   repository: hoprassociation/hopr-operator
   ## @param image.tag Docker image tag
   ##
-  tag: latest
-  ## @param image.pullPolicy Pull policy as deinfed in 
+  tag: 0.1.3
+  ## @param image.pullPolicy Pull policy as deinfed in
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##
-  pullPolicy: Always
+  pullPolicy: IfNotPresent
 
 service:
   ports:
-    ## @param service.ports.name Name of the API service port 
+    ## @param service.ports.name Name of the API service port
     ##
     name: api
 
@@ -116,4 +116,3 @@ metrics:
     ## @param metrics.serviceMonitor.selector Hord node instance selector labels
     ##
     selector: {}
-


### PR DESCRIPTION
## What
- [x] Add dockerignore to not incude unnecessary data in the build image.
- [x] Add cross-compilation using musl to generate a statically linked binary 
- [x] Fix and bump helm-chart 

## About
The hoprd operator is now an extremely tiny image that contains only the hoprd operator application and nothing else, minimizing the possible security issues:
```
$ docker image ls 
REPOSITORY                             TAG       IMAGE ID       CREATED       SIZE
gcr.io/hoprassociation/hopr-operator   latest    3ffd550a124c   2 hours ago   14.4MB
```

## Testing
If run without any kubectl specified, the app correctly terminates:
```
$ docker run -it --rm gcr.io/hoprassociation/hopr-operator:latest 
thread 'main' panicked at 'Expected a valid KUBECONFIG environment variable.: InferConfig(InferConfigError { in_cluster: ReadEnvironmentVariable(NotPresent), kubeconfig: ReadConfig(Os { code: 2, kind: NotFound, message: "No such file or directory" }, "/.kube/config") })', src/operator.rs:17:10
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```