### PR TITLE
Publishing helm package on GCP Artifact Registry

### DIFF
--- a/.github/workflows/container-master.yml
+++ b/.github/workflows/container-master.yml
@@ -1,6 +1,6 @@
 ---
 
-name: 'Container'
+name: 'Container merge'
 
 on:
   push:

--- a/.github/workflows/container-pr.yml
+++ b/.github/workflows/container-pr.yml
@@ -1,6 +1,6 @@
 ---
 
-name: 'Container'
+name: 'Container PR'
 
 on:
   pull_request:

--- a/.github/workflows/helm-build-and-test.yml
+++ b/.github/workflows/helm-build-and-test.yml
@@ -43,6 +43,7 @@ jobs:
 
       - name: helm package
         run: |
+          helm dependency build
           helm package . --version ${{ env.HELM_CHART_VERSION }}
         working-directory: 'charts/hoprd-operator/'
       - name: helm push

--- a/.github/workflows/helm-build-and-test.yml
+++ b/.github/workflows/helm-build-and-test.yml
@@ -41,12 +41,14 @@ jobs:
       - name: Artifact Registry authentication
         run: gcloud auth application-default print-access-token | helm registry login -u oauth2accesstoken --password-stdin https://europe-west3-docker.pkg.dev
 
-      - name: helm package
+      - name: Helm Package
         run: |
+          helm repo add mittwald https://helm.mittwald.de
+          helm repo update
           helm dependency build
           helm package . --version ${{ env.HELM_CHART_VERSION }}
         working-directory: 'charts/hoprd-operator/'
-      - name: helm push
+      - name: Helm Publish
         run: |
           helm push hoprd-operator-${{ env.HELM_CHART_VERSION }}.tgz oci://europe-west3-docker.pkg.dev/${{ secrets.GOOGLE_HOPRASSOCIATION_PROJECT }}/helm-hoprd-operator
         working-directory: 'charts/hoprd-operator/'

--- a/.github/workflows/helm-build-and-test.yml
+++ b/.github/workflows/helm-build-and-test.yml
@@ -19,7 +19,6 @@ jobs:
       - name: Validate Helm chart version
         run: |
           HELM_CHART_VERSION=$(grep '^version:' Chart.yaml | sed 's/.*: //')
-          echo "HELM_CHART_VERSION=${HELM_CHART_VERSION}" >> $GITHUB_ENV
           echo "The Helm chart version is '${HELM_CHART_VERSION}'"
           if git tag -l | grep helm-${HELM_CHART_VERSION} 1> /dev/null; then
             echo "The Helm chart version '${HELM_CHART_VERSION}' already exists. Please bump property 'version' on ./charts/Chart.yaml to a new version";
@@ -29,7 +28,6 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
-    needs: validate
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -40,4 +38,40 @@ jobs:
         run: |
           helm dependency update
           helm lint
+        working-directory: 'charts/hoprd-operator/'
+
+  package:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Get Helm chart version
+        run: |
+          HELM_CHART_VERSION=$(grep '^version:' Chart.yaml | sed 's/.*: //')
+          echo "HELM_CHART_VERSION=${HELM_CHART_VERSION}" >> $GITHUB_ENV
+        working-directory: 'charts/hoprd-operator/'
+
+      - name: Set up Google Cloud Credentials
+        uses: google-github-actions/auth@v1
+        with:
+          credentials_json: ${{ secrets.GOOGLE_HOPRASSOCIATION_CREDENTIALS_REGISTRY }}
+
+      - name: Set up Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@v1
+        with:
+          project_id: ${{ secrets.GOOGLE_HOPRASSOCIATION_PROJECT }}
+          install_components: beta
+
+      - name: Artifact Registry authentication
+        run: gcloud auth application-default print-access-token | helm registry login -u oauth2accesstoken --password-stdin https://europe-west3-docker.pkg.dev
+
+      - name: Helm Package
+        run: |
+          helm repo add mittwald https://helm.mittwald.de
+          helm repo update
+          helm dependency build
+          helm package . --version ${{ env.HELM_CHART_VERSION }}
         working-directory: 'charts/hoprd-operator/'

--- a/.github/workflows/helm-build-and-test.yml
+++ b/.github/workflows/helm-build-and-test.yml
@@ -27,32 +27,6 @@ jobs:
           fi
         working-directory: 'charts/hoprd-operator/'
 
-      - name: Set up Google Cloud Credentials
-        uses: google-github-actions/auth@v1
-        with:
-          credentials_json: ${{ secrets.GOOGLE_HOPRASSOCIATION_CREDENTIALS_REGISTRY }}
-
-      - name: Set up Google Cloud SDK
-        uses: google-github-actions/setup-gcloud@v1
-        with:
-          project_id: ${{ secrets.GOOGLE_HOPRASSOCIATION_PROJECT }}
-          install_components: beta
-
-      - name: Artifact Registry authentication
-        run: gcloud auth application-default print-access-token | helm registry login -u oauth2accesstoken --password-stdin https://europe-west3-docker.pkg.dev
-
-      - name: Helm Package
-        run: |
-          helm repo add mittwald https://helm.mittwald.de
-          helm repo update
-          helm dependency build
-          helm package . --version ${{ env.HELM_CHART_VERSION }}
-        working-directory: 'charts/hoprd-operator/'
-      - name: Helm Publish
-        run: |
-          helm push hoprd-operator-${{ env.HELM_CHART_VERSION }}.tgz oci://europe-west3-docker.pkg.dev/${{ secrets.GOOGLE_HOPRASSOCIATION_PROJECT }}/helm-hoprd-operator
-        working-directory: 'charts/hoprd-operator/'
-
   lint:
     runs-on: ubuntu-latest
     needs: validate

--- a/.github/workflows/helm-build-and-test.yml
+++ b/.github/workflows/helm-build-and-test.yml
@@ -18,10 +18,10 @@ jobs:
 
       - name: Validate Helm chart version
         run: |
-          HELM_CHART_VERSION=$(grep '^version:' Chart.yaml | sed 's/.*: /helm-/')
+          HELM_CHART_VERSION=$(grep '^version:' Chart.yaml | sed 's/.*: //')
           echo "HELM_CHART_VERSION=${HELM_CHART_VERSION}" >> $GITHUB_ENV
           echo "The Helm chart version is '${HELM_CHART_VERSION}'"
-          if git tag -l | grep ${HELM_CHART_VERSION} 1> /dev/null; then
+          if git tag -l | grep helm-${HELM_CHART_VERSION} 1> /dev/null; then
             echo "The Helm chart version '${HELM_CHART_VERSION}' already exists. Please bump property 'version' on ./charts/Chart.yaml to a new version";
             exit 1
           fi

--- a/.github/workflows/helm-build-and-test.yml
+++ b/.github/workflows/helm-build-and-test.yml
@@ -18,14 +18,35 @@ jobs:
 
       - name: Validate Helm chart version
         run: |
-          helm_chart_version=$(grep '^version:' Chart.yaml | sed 's/.*: /helm-/')
-          echo "The Helm chart version is '${helm_chart_version}'"
-          if git tag -l | grep ${helm_chart_version} 1> /dev/null; then
-            echo "The Helm chart version '${helm_chart_version}' already exists. Please bump property 'version' on ./charts/Chart.yaml to a new version";
+          HELM_CHART_VERSION=$(grep '^version:' Chart.yaml | sed 's/.*: /helm-/')
+          echo "HELM_CHART_VERSION=${HELM_CHART_VERSION}" >> $GITHUB_ENV
+          echo "The Helm chart version is '${HELM_CHART_VERSION}'"
+          if git tag -l | grep ${HELM_CHART_VERSION} 1> /dev/null; then
+            echo "The Helm chart version '${HELM_CHART_VERSION}' already exists. Please bump property 'version' on ./charts/Chart.yaml to a new version";
             exit 1
           fi
         working-directory: 'charts/hoprd-operator/'
 
+      - name: Set up Google Cloud Credentials
+        uses: google-github-actions/auth@v1
+        with:
+          credentials_json: ${{ secrets.GOOGLE_HOPRASSOCIATION_CREDENTIALS_REGISTRY }}
+
+      - name: Set up Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@v1
+        with:
+          project_id: ${{ secrets.GOOGLE_HOPRASSOCIATION_PROJECT }}
+          install_components: beta
+
+      - name: Artifact Registry authentication
+        run: gcloud auth application-default print-access-token | helm registry login -u oauth2accesstoken --password-stdin https://europe-west3-docker.pkg.dev
+
+      - name: helm package
+        run: |
+          helm package . --version ${{ env.HELM_CHART_VERSION }}
+      - name: helm push
+        run: |
+          helm push hoprd-operator-${{ env.HELM_CHART_VERSION }}.tgz oci://europe-west3-docker.pkg.dev/${{ secrets.GOOGLE_HOPRASSOCIATION_PROJECT }}/helm-hoprd-operator
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/helm-build-and-test.yml
+++ b/.github/workflows/helm-build-and-test.yml
@@ -1,6 +1,6 @@
 ---
 
-name: 'Helm chart'
+name: 'Helm chart build'
 
 on:
   pull_request:
@@ -44,9 +44,11 @@ jobs:
       - name: helm package
         run: |
           helm package . --version ${{ env.HELM_CHART_VERSION }}
+        working-directory: 'charts/hoprd-operator/'
       - name: helm push
         run: |
           helm push hoprd-operator-${{ env.HELM_CHART_VERSION }}.tgz oci://europe-west3-docker.pkg.dev/${{ secrets.GOOGLE_HOPRASSOCIATION_PROJECT }}/helm-hoprd-operator
+        working-directory: 'charts/hoprd-operator/'
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/helm-generate-readme.yml
+++ b/.github/workflows/helm-generate-readme.yml
@@ -1,6 +1,6 @@
 ---
 
-name: 'Helm chart'
+name: 'Helm chart readme'
 
 on:
   pull_request:

--- a/.github/workflows/helm-publish.yml
+++ b/.github/workflows/helm-publish.yml
@@ -21,8 +21,8 @@ jobs:
 
       - name: Get Helm chart version
         run: |
-          helm_chart_version=$(grep '^version:' Chart.yaml | sed 's/.*: //')
-          echo "HELM_CHART_VERSION=helm-${helm_chart_version}" >> $GITHUB_ENV
+          HELM_CHART_VERSION=$(grep '^version:' Chart.yaml | sed 's/.*: //')
+          echo "HELM_CHART_VERSION=helm-${HELM_CHART_VERSION}" >> $GITHUB_ENV
         working-directory: 'charts/hoprd-operator/'
 
       - name: Tag Helm version

--- a/.github/workflows/helm-publish.yml
+++ b/.github/workflows/helm-publish.yml
@@ -22,12 +22,38 @@ jobs:
       - name: Get Helm chart version
         run: |
           HELM_CHART_VERSION=$(grep '^version:' Chart.yaml | sed 's/.*: //')
-          echo "HELM_CHART_VERSION=helm-${HELM_CHART_VERSION}" >> $GITHUB_ENV
+          echo "HELM_CHART_VERSION=${HELM_CHART_VERSION}" >> $GITHUB_ENV
+        working-directory: 'charts/hoprd-operator/'
+
+      - name: Set up Google Cloud Credentials
+        uses: google-github-actions/auth@v1
+        with:
+          credentials_json: ${{ secrets.GOOGLE_HOPRASSOCIATION_CREDENTIALS_REGISTRY }}
+
+      - name: Set up Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@v1
+        with:
+          project_id: ${{ secrets.GOOGLE_HOPRASSOCIATION_PROJECT }}
+          install_components: beta
+
+      - name: Artifact Registry authentication
+        run: gcloud auth application-default print-access-token | helm registry login -u oauth2accesstoken --password-stdin https://europe-west3-docker.pkg.dev
+
+      - name: Helm Package
+        run: |
+          helm repo add mittwald https://helm.mittwald.de
+          helm repo update
+          helm dependency build
+          helm package . --version ${{ env.HELM_CHART_VERSION }}
+        working-directory: 'charts/hoprd-operator/'
+      - name: Helm Publish
+        run: |
+          helm push hoprd-operator-${{ env.HELM_CHART_VERSION }}.tgz oci://europe-west3-docker.pkg.dev/${{ secrets.GOOGLE_HOPRASSOCIATION_PROJECT }}/helm-charts
         working-directory: 'charts/hoprd-operator/'
 
       - name: Tag Helm version
         run: |
             git config user.email "noreply@hoprnet.org"
             git config user.name "HOPR CI robot"
-            git tag ${{ env.HELM_CHART_VERSION }}
+            git tag helm-${{ env.HELM_CHART_VERSION }}
             git push origin ${{ env.HELM_CHART_VERSION }}

--- a/.github/workflows/helm-publish.yml
+++ b/.github/workflows/helm-publish.yml
@@ -1,6 +1,6 @@
 ---
 
-name: 'Helm chart'
+name: 'Helm chart publish'
 
 on:
   push:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,7 +406,7 @@ dependencies = [
 
 [[package]]
 name = "hopr_operator"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "async-recursion",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr_operator"
-version = "0.1.5"
+version = "0.1.6"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2021"
 

--- a/charts/hoprd-operator/Chart.yaml
+++ b/charts/hoprd-operator/Chart.yaml
@@ -2,7 +2,10 @@
 
 apiVersion: v2
 name: hoprd-operator
-version: 0.1.5
+# Helm chart version
+version: 0.1.6
+# hoprd-operator docker image version
+appVersion: 0.1.6
 description: A Helm chart operator for managing Hopr nodes
 type: application
 icon: "https://hoprnet.org/assets/icons/logo.svg"

--- a/charts/hoprd-operator/README.md
+++ b/charts/hoprd-operator/README.md
@@ -78,7 +78,7 @@ Chart version `Chart.yaml` should be increased according to [semver](http://semv
 | `operator.affinity`                     | Affinity specifications to operator deployment                                                                   | `{}`                             |
 | `operator.image.registry`               | Docker registry to operator deployment                                                                           | `gcr.io`                         |
 | `operator.image.repository`             | Docker image repository to operator deployment                                                                   | `hoprassociation/hoprd-operator` |
-| `operator.image.tag`                    | Docker image tag to operator deployment                                                                          | `0.1.5`                          |
+| `operator.image.tag`                    | Docker image tag to operator deployment                                                                          | `""`                             |
 | `operator.image.pullPolicy`             | Pull policy to operator deployment as deinfed in                                                                 | `IfNotPresent`                   |
 
 ### Service Parameters

--- a/charts/hoprd-operator/templates/deployment-operator.yaml
+++ b/charts/hoprd-operator/templates/deployment-operator.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       - name: operator
-        image: {{ printf "%s/%s:%s" .Values.operator.image.registry .Values.operator.image.repository .Values.operator.image.tag }}
+        image: "{{ .Values.operator.image.registry }}/{{ .Values.operator.image.repository }}:{{ default .Chart.AppVersion .Values.operator.image.tag }}"
         imagePullPolicy: {{ .Values.operator.image.pullPolicy }}
         securityContext:
           allowPrivilegeEscalation: false

--- a/charts/hoprd-operator/values.yaml
+++ b/charts/hoprd-operator/values.yaml
@@ -172,7 +172,7 @@ operator:
 
     ## @param operator.image.tag Docker image tag to operator deployment
     ##
-    tag: 0.1.5
+    tag: ""
 
     ## @param operator.image.pullPolicy Pull policy to operator deployment as deinfed in 
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
In order to use ArgoCD I would like to work with an existing HelmChart repository. In this PR I improve github actions to publish the helm chart in GCP Artifact Registry so it can be downloaded as:
`helm install hoprd-operator oci://europe-west3-docker.pkg.dev/hoprassociation/helm-charts/hoprd-operator --version 0.1.6`