### PR TITLE
Fix the use of secretName on creating jobs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,7 +406,7 @@ dependencies = [
 
 [[package]]
 name = "hopr_operator"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "async-recursion",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr_operator"
-version = "0.1.10"
+version = "0.1.11"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2021"
 

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ install:
 uninstall:
 	helm uninstall --namespace hoprd hoprd-operator
 	kubectl delete sa -n hoprd hoprd-operator hoprd-operator-kubernetes-replicator
+	kubectl delete crds hoprds.hoprnet.org
 
 upgrade:
 	helm upgrade --namespace hoprd --create-namespace -f ./charts/hoprd-operator/testValues.yaml hoprd-operator ./charts/hoprd-operator/

--- a/charts/hoprd-operator/Chart.yaml
+++ b/charts/hoprd-operator/Chart.yaml
@@ -2,8 +2,8 @@
 
 apiVersion: v2
 name: hoprd-operator
-version: 0.1.15
-appVersion: 0.1.9
+version: 0.1.16
+appVersion: 0.1.11
 description: A Helm chart operator for managing Hopr nodes
 type: application
 icon: "https://hoprnet.org/assets/icons/logo.svg"

--- a/charts/hoprd-operator/templates/configmap-config.yaml
+++ b/charts/hoprd-operator/templates/configmap-config.yaml
@@ -18,6 +18,11 @@ data:
     instance:
       name: {{ include "hoprd-operator.fullname" . | quote }}
       namespace: {{ .Release.Namespace | quote }}
+    {{- if .Values.operator.secretName }}
+      secret_name: "{{- .Values.operator.secretName }}"
+    {{- else }}
+      secret_name: "{{ include "hoprd-operator.fullname" . }}"
+    {{- end }}
     ingress:
       ingress_class_name: "{{- .Values.operator.ingress.ingressClassName }}"
       dns_domain: "{{- .Values.operator.ingress.dnsDomain }}"

--- a/sample_config.yaml
+++ b/sample_config.yaml
@@ -1,6 +1,7 @@
 instance:
   name: "hoprd-operator"
   namespace: "hoprd"
+  secret_name: "hoprd-operator-wallet"
 ingress:
   ingress_class_name: "nginx"
   dns_domain: "stage.hoprtech.net"

--- a/src/hoprd_jobs.rs
+++ b/src/hoprd_jobs.rs
@@ -284,7 +284,7 @@ pub async fn build_env_vars(client: Client, hoprd_spec: &HoprdSpec, is_create_no
         value_from: Some(EnvVarSource {
             secret_key_ref: Some(SecretKeySelector {
                 key: constants::HOPR_PRIVATE_KEY.to_owned(),
-                name: Some(operator_instance.name.to_owned()),
+                name: Some(operator_instance.secret_name.to_owned()),
                 ..SecretKeySelector::default()
             }),
             ..EnvVarSource::default()

--- a/src/model.rs
+++ b/src/model.rs
@@ -118,7 +118,8 @@ pub struct OperatorConfig {
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone, Hash)]
 pub struct OperatorInstance {
     pub name: String,
-    pub namespace: String
+    pub namespace: String,
+    pub secret_name: String
 }
 
 


### PR DESCRIPTION
The operator was locally tested using as secret provided on the values instead of provided by an existing secret. When the secret is provided, then the operator needs to use that name.