### PR TITLE
Adding metric relabeling to ServiceMonitor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -412,7 +412,7 @@ dependencies = [
 
 [[package]]
 name = "hopr_operator"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "async-recursion",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr_operator"
-version = "0.1.21"
+version = "0.1.22"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2021"
 

--- a/hoprd-node-1.yaml
+++ b/hoprd-node-1.yaml
@@ -22,48 +22,48 @@ spec:
       requests:
         cpu: 750m
         memory: 256Mi
-    startupProbe: |
-      exec:
-        command:
-          - sh
-          - '-c'
-          - >-
-            curl -s http://localhost:3001/api/v2/node/info -H
-            "X-Auth-Token: $HOPRD_API_TOKEN" | jq -r .connectivityStatus |
-            grep -q Green
-      initialDelaySeconds: 5
-      timeoutSeconds: 5
-      periodSeconds: 30
-      successThreshold: 1
-      failureThreshold: 60
-    livenessProbe: |
-      exec:
-        command:
-          - sh
-          - '-c'
-          - >-
-            curl -s http://localhost:3001/api/v2/node/info -H
-            "X-Auth-Token: $HOPRD_API_TOKEN" | jq -r .connectivityStatus |
-            grep -q Green
-      initialDelaySeconds: 5
-      timeoutSeconds: 5
-      periodSeconds: 10
-      successThreshold: 1
-      failureThreshold: 5
-    readinessProbe: |
-      exec:
-        command:
-          - sh
-          - '-c'
-          - >-
-            curl -s http://localhost:3001/api/v2/node/info -H
-            "X-Auth-Token: $HOPRD_API_TOKEN" | jq -r .connectivityStatus |
-            grep -q Green
-      initialDelaySeconds: 5
-      timeoutSeconds: 5
-      periodSeconds: 10
-      successThreshold: 1
-      failureThreshold: 5
+    # startupProbe: |
+    #   exec:
+    #     command:
+    #       - sh
+    #       - '-c'
+    #       - >-
+    #         curl -s http://localhost:3001/api/v2/node/info -H
+    #         "X-Auth-Token: $HOPRD_API_TOKEN" | jq -r .connectivityStatus |
+    #         grep -q Green
+    #   initialDelaySeconds: 5
+    #   timeoutSeconds: 5
+    #   periodSeconds: 30
+    #   successThreshold: 1
+    #   failureThreshold: 60
+    # livenessProbe: |
+    #   exec:
+    #     command:
+    #       - sh
+    #       - '-c'
+    #       - >-
+    #         curl -s http://localhost:3001/api/v2/node/info -H
+    #         "X-Auth-Token: $HOPRD_API_TOKEN" | jq -r .connectivityStatus |
+    #         grep -q Green
+    #   initialDelaySeconds: 5
+    #   timeoutSeconds: 5
+    #   periodSeconds: 10
+    #   successThreshold: 1
+    #   failureThreshold: 5
+    # readinessProbe: |
+    #   exec:
+    #     command:
+    #       - sh
+    #       - '-c'
+    #       - >-
+    #         curl -s http://localhost:3001/api/v2/node/info -H
+    #         "X-Auth-Token: $HOPRD_API_TOKEN" | jq -r .connectivityStatus |
+    #         grep -q Green
+    #   initialDelaySeconds: 5
+    #   timeoutSeconds: 5
+    #   periodSeconds: 10
+    #   successThreshold: 1
+    #   failureThreshold: 5
 # ---
 # apiVersion: hoprnet.org/v1alpha
 # kind: Hoprd

--- a/src/hoprd_deployment.rs
+++ b/src/hoprd_deployment.rs
@@ -1,4 +1,4 @@
-use k8s_openapi::api::apps::v1::{Deployment, DeploymentSpec};
+use k8s_openapi::api::apps::v1::{Deployment, DeploymentSpec, DeploymentStrategy};
 use k8s_openapi::api::core::v1::{
     Container, ContainerPort, EnvVar, EnvVarSource, KeyToPath,
     PodSpec, PodTemplateSpec, Probe, SecretKeySelector, SecretVolumeSource,
@@ -75,6 +75,10 @@ pub async fn build_deployment_spec(labels: BTreeMap<String, String>, hoprd_spec:
 
     DeploymentSpec {
             replicas: Some(replicas),
+            strategy: Some(DeploymentStrategy{
+                type_: Some("Recreate".to_owned()),
+                ..DeploymentStrategy::default()
+            }),
             selector: LabelSelector {
                 match_expressions: None,
                 match_labels: Some(labels.clone()),


### PR DESCRIPTION
- Fix a problem when restarting a hoprd node deployment with the mounted volume. As it was already mounted by the previous pod, the new pod could not mount it and failed. 
- Add different labels to prometheus metrics so it can easily be filtered in Grafana.