### PR TITLE
Fix scale down of nodes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -411,7 +411,7 @@ dependencies = [
 
 [[package]]
 name = "hoprd_operator"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "async-recursion",
  "base64",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -411,7 +411,7 @@ dependencies = [
 
 [[package]]
 name = "hoprd_operator"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "async-recursion",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hoprd_operator"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2021"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hoprd_operator"
-version = "0.2.3"
+version = "0.2.4"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2021"
 

--- a/Makefile
+++ b/Makefile
@@ -51,13 +51,18 @@ docker-push: ## Deploys docker image into GCP Artifact registry
 	docker push europe-west3-docker.pkg.dev/hoprassociation/docker-images/hoprd-operator:latest
 
 create-identity: ## Create identity resources
-	kubectl apply -f ./test-data/identity-pool.yaml
-	kubectl apply -f ./test-data/identity-hoprd.yaml
-	kubectl patch -n hoprd-operator IdentityPool pool-hoprd-operator --type='json' -p='[{"op": "replace", "path": "/spec/minReadyIdentities", "value":1}]'
-	kubectl patch -n rotsee IdentityPool core-rotsee --type='json' -p='[{"op": "replace", "path": "/spec/minReadyIdentities", "value":1}]'
+	kubectl apply -f ../hoprd-nodes/rotsee/devops/identities/sealed-secret-hoprd-operator.yaml
+	kubectl apply -f ../hoprd-nodes/rotsee/devops/identities/identity-pool.yaml
+	kubectl apply -f ../hoprd-nodes/rotsee/devops/identities/identity-hoprds-devops-1.yaml
+	kubectl apply -f ../hoprd-nodes/rotsee/devops/identities/identity-hoprds-devops-2.yaml
+	# kubectl patch -n hoprd-operator IdentityPool pool-hoprd-operator --type='json' -p='[{"op": "replace", "path": "/spec/minReadyIdentities", "value":1}]'
+	# kubectl patch -n rotsee IdentityPool core-rotsee --type='json' -p='[{"op": "replace", "path": "/spec/minReadyIdentities", "value":1}]'
 
 delete-identity: ## Deletes identity resources
-	kubectl patch -n hoprd-operator IdentityPool pool-hoprd-operator --type='json' -p='[{"op": "replace", "path": "/spec/minReadyIdentities", "value":0}]'
-	kubectl patch -n rotsee IdentityPool core-rotsee --type='json' -p='[{"op": "replace", "path": "/spec/minReadyIdentities", "value":0}]'
-	kubectl delete -f ./test-data/identity-hoprd.yaml
-	kubectl apply -f ./test-data/identity-pool.yaml
+	# kubectl patch -n hoprd-operator IdentityPool pool-hoprd-operator --type='json' -p='[{"op": "replace", "path": "/spec/minReadyIdentities", "value":0}]'
+	# kubectl patch -n rotsee IdentityPool core-rotsee --type='json' -p='[{"op": "replace", "path": "/spec/minReadyIdentities", "value":0}]'
+	kubectl delete -f ./hoprd-nodes/rotsee/devops/identities/identity-hoprds-devops-1.yaml
+	kubectl delete -f ./hoprd-nodes/rotsee/devops/identities/identity-hoprds-devops-2.yaml
+	kubectl delete -f ../hoprd-nodes/rotsee/devops/identities/identity-pool.yaml
+	kubectl delete -f ../hoprd-nodes/rotsee/devops/identities/sealed-secret-hoprd-operator.yaml
+

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,11 @@ gcp-login: ## Login into GCP
 	gcloud auth configure-docker europe-west3-docker.pkg.dev
 	gcloud auth application-default print-access-token | helm registry login -u oauth2accesstoken --password-stdin https://europe-west3-docker.pkg.dev
 
+.PHONY: lint-rust
+lint-rust: ## run linter for Rust
+	cargo fmt --check
+	cargo clippy -- -Dwarnings
+
 build: ## Rust build
 	cargo build
 

--- a/charts/cluster-hoprd/Chart.yaml
+++ b/charts/cluster-hoprd/Chart.yaml
@@ -2,7 +2,7 @@
 
 apiVersion: v2
 name: cluster-hoprd
-version: 0.2.1
+version: 0.2.2
 description: A Helm chart to deploy ClusterHoprd
 type: application
 icon: "https://hoprnet.org/assets/icons/logo.svg"

--- a/charts/cluster-hoprd/README.md
+++ b/charts/cluster-hoprd/README.md
@@ -15,11 +15,13 @@ This chart packages the creation of a ClusterHoprd
 
 ### Cluster Hoprd parameters
 
-| Name                   | Description                   | Value   |
-| ---------------------- | ----------------------------- | ------- |
-| `identityPoolName`     | Name of the identity pool     | `""`    |
-| `replicas`             | Number of instances           | `1`     |
-| `version`              | Hoprd node version to run     | `2.0.2` |
-| `enabled`              | Running status of the nodes   | `true`  |
-| `deployment.resources` | Deployment resources spec     | `""`    |
-| `config`               | Custom configuration of nodes | `""`    |
+| Name                   | Description                                             | Value   |
+| ---------------------- | ------------------------------------------------------- | ------- |
+| `identityPoolName`     | Name of the identity pool                               | `""`    |
+| `replicas`             | Number of instances                                     | `1`     |
+| `version`              | Hoprd node version to run                               | `2.0.2` |
+| `enabled`              | Running status of the nodes                             | `true`  |
+| `supportedRelease`     | The kind of supported release <providence|saint-louis>  | `""`    |
+| `forceIdentityName`    | Forces identity names to be set in child Hopd resources | `false` |
+| `deployment.resources` | Deployment resources spec                               | `""`    |
+| `config`               | Custom configuration of nodes                           | `""`    |

--- a/charts/cluster-hoprd/templates/cluster-hoprd.yaml
+++ b/charts/cluster-hoprd/templates/cluster-hoprd.yaml
@@ -9,6 +9,7 @@ spec:
   replicas: {{ .Values.replicas }}
   version: {{ .Values.version | quote }}
   enabled: {{ .Values.enabled }}
+  supportedRelease: {{ .Values.supportedRelease }}
   forceIdentityName: {{ .Values.forceIdentityName }}
   {{- if .Values.deployment.resources }}
   deployment: 

--- a/charts/cluster-hoprd/values.yaml
+++ b/charts/cluster-hoprd/values.yaml
@@ -27,6 +27,11 @@ version: 2.0.2
 enabled: true
 
 ##
+## @param supportedRelease The kind of supported release <providence|saint-louis>
+##
+supportedRelease: ""
+
+##
 ## @param forceIdentityName Forces identity names to be set in child Hopd resources
 ##
 forceIdentityName: false

--- a/charts/hoprd-operator/Chart.yaml
+++ b/charts/hoprd-operator/Chart.yaml
@@ -2,8 +2,8 @@
 
 apiVersion: v2
 name: hoprd-operator
-version: 0.2.3
-appVersion: 0.2.2
+version: 0.2.4
+appVersion: 0.2.3
 description: A Helm chart operator for managing Hopr nodes
 type: application
 icon: "https://hoprnet.org/assets/icons/logo.svg"

--- a/charts/hoprd-operator/Chart.yaml
+++ b/charts/hoprd-operator/Chart.yaml
@@ -3,7 +3,7 @@
 apiVersion: v2
 name: hoprd-operator
 version: 0.2.4
-appVersion: 0.2.3
+appVersion: 0.2.4
 description: A Helm chart operator for managing Hopr nodes
 type: application
 icon: "https://hoprnet.org/assets/icons/logo.svg"

--- a/charts/hoprd-operator/templates/crd-cluster-hoprd.yaml
+++ b/charts/hoprd-operator/templates/crd-cluster-hoprd.yaml
@@ -85,6 +85,9 @@ spec:
                   type: object
                   description: Deployment configuration
                   properties:
+                    env:
+                      type: string
+                      description: The definition for environment variables to be used by the node deployment
                     resources:
                       type: string
                       description: The definition for hardware resources to be used by the node deployment

--- a/charts/hoprd-operator/templates/crd-cluster-hoprd.yaml
+++ b/charts/hoprd-operator/templates/crd-cluster-hoprd.yaml
@@ -72,6 +72,12 @@ spec:
                 enabled:
                   type: boolean
                   description: 'Flag indicating if the node should be started or stopped'
+                supportedRelease:
+                  type: string
+                  description: 'Release Name of the supported version'
+                  enum:
+                    - providence
+                    - saint-louis
                 forceIdentityName:
                   type: boolean
                   description: Flag indicating whether the identityName should be specified in child Hoprd
@@ -96,6 +102,7 @@ spec:
                 - replicas
                 - config
                 - version
+                - supportedRelease
             status:
               description: The status object of ClusterHord node
               nullable: true

--- a/charts/hoprd-operator/templates/crd-cluster-hoprd.yaml
+++ b/charts/hoprd-operator/templates/crd-cluster-hoprd.yaml
@@ -42,10 +42,10 @@ spec:
           type: number
           description: Replicas
           jsonPath: .spec.replicas
-        - name: Running
+        - name: Current
           type: number
           description: Nodes running
-          jsonPath: .status.runningNodes
+          jsonPath: .status.currentNodes
         - name: Age
           type: date
           jsonPath: .metadata.creationTimestamp
@@ -117,10 +117,10 @@ spec:
                   - Failed
                   - Ready
                   - Deleting
-                runningNodes:
+                currentNodes:
                   type: number
                   description: Number of nodes running
-              required: [ "updateTimestamp", "checksum", "phase", "runningNodes"]
+              required: [ "updateTimestamp", "checksum", "phase", "currentNodes"]
               type: object
           required:
             - spec

--- a/charts/hoprd-operator/templates/crd-hoprd.yaml
+++ b/charts/hoprd-operator/templates/crd-hoprd.yaml
@@ -30,6 +30,10 @@ spec:
           type: string
           description: Hoprd phase
           jsonPath: .status.phase
+        - name: Version
+          type: string
+          description: Version
+          jsonPath: .spec.version
         - name: IdentityHoprd
           type: string
           description: Hoprd Name

--- a/charts/hoprd-operator/templates/crd-hoprd.yaml
+++ b/charts/hoprd-operator/templates/crd-hoprd.yaml
@@ -55,6 +55,12 @@ spec:
                 enabled:
                   type: boolean
                   description: 'Flag indicating if the node should be started or stopped'
+                supportedRelease:
+                  type: string
+                  description: 'Release Name of the supported version'
+                  enum:
+                    - providence
+                    - saint-louis
                 deployment:
                   type: object
                   description: Deployment configuration
@@ -80,7 +86,10 @@ spec:
                 version:
                   type: string
                   description: 'An specific hoprd version. Should match with a docker tag'
-              required: ["version", "identityPoolName"]
+              required: 
+                - version
+                - identityPoolName
+                - supportedRelease
             status:
               description: The status object of Hoprd node
               nullable: true

--- a/charts/hoprd-operator/templates/crd-hoprd.yaml
+++ b/charts/hoprd-operator/templates/crd-hoprd.yaml
@@ -65,6 +65,9 @@ spec:
                   type: object
                   description: Deployment configuration
                   properties:
+                    env:
+                      type: string
+                      description: The definition for environment variables to be used by the node deployment
                     resources:
                       type: string
                       description: The definition for hardware resources to be used by the node deployment

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,5 @@
+[toolchain]
+channel = "1.75"
+profile = "default"
+components = [ "cargo", "clippy", "rust-src" ]
+targets = [ "x86_64-unknown-linux-gnu" ]

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,5 @@
+edition = "2021"
+reorder_imports = true
+fn_params_layout = "Tall"
+# group_imports = "StdExternalCrate"
+max_width=120

--- a/scripts/create-identity-dummy.sh
+++ b/scripts/create-identity-dummy.sh
@@ -15,7 +15,7 @@ chmod +x /app/hoprd-identity-created/create-resource.sh
 
 echo "{\"crypto\":{\"cipher\":\"aes-128-ctr\",\"cipherparams\":{\"iv\":\"0c8e445f7b57afa284f1e824ae9a930c\"},\"ciphertext\":\"f565dd77db497ff7bc9d9a8c81c76ad9f25e2a3cfff1464ed233275f30e06c26a1cfac6a018765aabe3bc392a9f4910f941f00d35eb7aa2476fb4fdafef1025a284c4cbf1b834f4ba53a6b65df6b44f196e0c72906aa967ffafcec479f7a4bd7aed87fd946eeb78d9e236ae10746ae153bdf47ae469bcb0f3c3262eacf440d9d36ce97e15bd768eb95e71f93afde10e69c1c350037a20c46be0a6edc52ae4210f3a70787ed0f2735346a35f7\",\"kdf\":\"scrypt\",\"kdfparams\":{\"dklen\":32,\"n\":8192,\"p\":1,\"r\":8,\"salt\":\"f3b68cc82430f45344ea95d0b339dc08987196c3fe6e9bd2c6649fd0de2f0ca0\"},\"mac\":\"273f15cdbe8869bf844e8845b07cd17a15e2c17c511e8b364f77b7e30e2dd1a8\"},\"id\":\"4ae9d885-d0b0-4eb0-a6f0-fc0fe70e6f31\",\"version\":3}" > /app/hoprd-identity-created/.hoprd0.id
 echo "{ \".hoprd0.id\": { \"peer_id\": \"12D3KooWGh8WFFuXEZvDSDrv17CYieUxeMrbvwow2WbgUyMB4dqW\", \"packet_key\": \"0x66274b0cbf82e01dbc9b3b2adde13fc6677dcf083c0b57d8c932d9b6a5f1b625\", \"chain_key\": \"0x0310668dd2baa587858b4d98d6b9c6529207511e8c9cce5f814b80f5c01ce70c7c\", \"native_address\": \"0x915ab25afe89849084c021377dba14181e6839f4\", \"uuid\": \"4ae9d885-d0b0-4eb0-a6f0-fc0fe70e6f31\" }, \"safe_address\": \"0x0D4Ec909963D2866B544cd0F6a7099C48a2dcE2f\", \"module_address\": \"0x7F699cB986Fe36314b23139e88583fB79831aEc6\" }" > /app/hoprd-identity-created/hoprd.json
-echo "Successfully changed working directory to /Users/ausias/Documents/github/hoprnet/scripts/../packages/ethereum/contracts!
+echo "Successfully changed working directory to /Users/ausias/Documents/github/hoprnet/scripts/../ethereum/contracts!
 No files changed, compilation skipped
 Script ran successfully.
 

--- a/scripts/create-identity-dummy.sh
+++ b/scripts/create-identity-dummy.sh
@@ -15,7 +15,7 @@ chmod +x /app/hoprd-identity-created/create-resource.sh
 
 echo "{\"crypto\":{\"cipher\":\"aes-128-ctr\",\"cipherparams\":{\"iv\":\"0c8e445f7b57afa284f1e824ae9a930c\"},\"ciphertext\":\"f565dd77db497ff7bc9d9a8c81c76ad9f25e2a3cfff1464ed233275f30e06c26a1cfac6a018765aabe3bc392a9f4910f941f00d35eb7aa2476fb4fdafef1025a284c4cbf1b834f4ba53a6b65df6b44f196e0c72906aa967ffafcec479f7a4bd7aed87fd946eeb78d9e236ae10746ae153bdf47ae469bcb0f3c3262eacf440d9d36ce97e15bd768eb95e71f93afde10e69c1c350037a20c46be0a6edc52ae4210f3a70787ed0f2735346a35f7\",\"kdf\":\"scrypt\",\"kdfparams\":{\"dklen\":32,\"n\":8192,\"p\":1,\"r\":8,\"salt\":\"f3b68cc82430f45344ea95d0b339dc08987196c3fe6e9bd2c6649fd0de2f0ca0\"},\"mac\":\"273f15cdbe8869bf844e8845b07cd17a15e2c17c511e8b364f77b7e30e2dd1a8\"},\"id\":\"4ae9d885-d0b0-4eb0-a6f0-fc0fe70e6f31\",\"version\":3}" > /app/hoprd-identity-created/.hoprd0.id
 echo "{ \".hoprd0.id\": { \"peer_id\": \"12D3KooWGh8WFFuXEZvDSDrv17CYieUxeMrbvwow2WbgUyMB4dqW\", \"packet_key\": \"0x66274b0cbf82e01dbc9b3b2adde13fc6677dcf083c0b57d8c932d9b6a5f1b625\", \"chain_key\": \"0x0310668dd2baa587858b4d98d6b9c6529207511e8c9cce5f814b80f5c01ce70c7c\", \"native_address\": \"0x915ab25afe89849084c021377dba14181e6839f4\", \"uuid\": \"4ae9d885-d0b0-4eb0-a6f0-fc0fe70e6f31\" }, \"safe_address\": \"0x0D4Ec909963D2866B544cd0F6a7099C48a2dcE2f\", \"module_address\": \"0x7F699cB986Fe36314b23139e88583fB79831aEc6\" }" > /app/hoprd-identity-created/hoprd.json
-echo "Successfully changed working directory to /Users/ausias/Documents/github/hoprnet/scripts/../ethereum/contracts!
+echo "
 No files changed, compilation skipped
 Script ran successfully.
 

--- a/scripts/create-identity.sh
+++ b/scripts/create-identity.sh
@@ -9,7 +9,7 @@ export PRIVATE_KEY=${DEPLOYER_PRIVATE_KEY}
 set -x
 
 /bin/hopli identity --action create --identity-directory /app/hoprd-identity-created --identity-prefix .hoprd | tee /app/hoprd-identity-created/hoprd.json
-/bin/hopli create-safe-module --contracts-root /app/hoprnet/packages/ethereum/contracts/ --network "${HOPRD_NETWORK}" --identity-from-path /app/hoprd-identity-created/.hoprd0.id --hopr-amount "10" --native-amount "0.01" | tee /app/hoprd-identity-created/create-safe-module.log
+/bin/hopli create-safe-module --contracts-root /app/hoprnet/ethereum/contracts/ --network "${HOPRD_NETWORK}" --identity-from-path /app/hoprd-identity-created/.hoprd0.id --hopr-amount "10" --native-amount "0.01" | tee /app/hoprd-identity-created/create-safe-module.log
 
 # Download the next script here because the kubectl image does not have curl or wget
 curl -s ${JOB_SCRIPT_URL} > /app/hoprd-identity-created/create-resource.sh

--- a/src/bootstrap_operator.rs
+++ b/src/bootstrap_operator.rs
@@ -20,10 +20,7 @@ use tracing::error;
 use crate::{context_data::ContextData, operator_config::IngressConfig};
 
 // Modifies Nginx deployment to add a range of ports that will be used by the operator while creating new nodes
-async fn open_nginx_deployment_ports(
-    client: Client,
-    ingress_config: &IngressConfig,
-) -> Result<(), HoprError> {
+async fn open_nginx_deployment_ports(client: Client, ingress_config: &IngressConfig) -> Result<(), HoprError> {
     let namespace = ingress_config.namespace.as_ref().unwrap();
     let min_port = ingress_config.p2p_port_min.as_ref().unwrap().parse::<i32>().unwrap();
     let max_port = ingress_config.p2p_port_max.as_ref().unwrap().parse::<i32>().unwrap();
@@ -40,13 +37,13 @@ async fn open_nginx_deployment_ports(
     for port_number in min_port..max_port {
         new_deployment_ports.push(ContainerPort {
             container_port: port_number,
-            name: Some(format!("{}-tcp", port_number.to_string())),
+            name: Some(format!("{}-tcp", port_number)),
             protocol: Some("TCP".to_string()),
             ..ContainerPort::default()
         });
         new_deployment_ports.push(ContainerPort {
             container_port: port_number,
-            name: Some(format!("{}-udp", port_number.to_string())),
+            name: Some(format!("{}-udp", port_number)),
             protocol: Some("UDP".to_string()),
             ..ContainerPort::default()
         });
@@ -66,10 +63,7 @@ async fn open_nginx_deployment_ports(
 }
 
 // Modifies Nginx service to add a range of ports that will be used by the operator while creating new nodes
-async fn open_nginx_service_ports(
-    client: Client,
-    ingress_config: &IngressConfig,
-) -> Result<(), HoprError> {
+async fn open_nginx_service_ports(client: Client, ingress_config: &IngressConfig) -> Result<(), HoprError> {
     let namespace = ingress_config.namespace.as_ref().unwrap();
     let min_port = ingress_config.p2p_port_min.as_ref().unwrap().parse::<i32>().unwrap();
     let max_port = ingress_config.p2p_port_max.as_ref().unwrap().parse::<i32>().unwrap();
@@ -85,14 +79,14 @@ async fn open_nginx_service_ports(
     for port_number in min_port..max_port {
         new_service_ports.push(ServicePort {
             port: port_number,
-            name: Some(format!("{}-tcp", port_number.to_string())),
+            name: Some(format!("{}-tcp", port_number)),
             protocol: Some("TCP".to_string()),
             target_port: Some(IntOrString::Int(port_number)),
             ..ServicePort::default()
         });
         new_service_ports.push(ServicePort {
             port: port_number,
-            name: Some(format!("{}-udp", port_number.to_string())),
+            name: Some(format!("{}-udp", port_number)),
             protocol: Some("UDP".to_string()),
             target_port: Some(IntOrString::Int(port_number)),
             ..ServicePort::default()
@@ -111,7 +105,7 @@ async fn open_nginx_service_ports(
 }
 
 /// Boot operator
-pub async fn start(client: Client, context_data: Arc<ContextData>) -> () {
+pub async fn start(client: Client, context_data: Arc<ContextData>) {
     // Open Nginx Ports
     if context_data.config.ingress.ingress_class_name == "nginx" {
         open_nginx_deployment_ports(client.clone(), &context_data.config.ingress).await.unwrap();

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -191,7 +191,7 @@ impl ClusterHoprd {
         let mut annotations = BTreeMap::new();
         annotations.insert(constants::ANNOTATION_LAST_CONFIGURATION.to_string(), cluster_last_configuration);
         let patch = Patch::Merge(json!({
-            "metadata": { 
+            "metadata": {
                 "annotations": annotations 
             }
         }));
@@ -312,7 +312,7 @@ impl ClusterHoprd {
         let patch = Patch::Merge(json!({"status": cluster_hoprd_status }));
         match api.patch(&cluster_hoprd_name, &PatchParams::default(), &patch).await
         {
-            Ok(_cluster_hopr) => Ok(()),
+            Ok(_cluster_hopr) => Ok(debug!("ClusterHoprd current status {:?}", cluster_hoprd_status)),
             Err(error) => Ok(error!("Could not update phase {} on cluster {cluster_hoprd_name}: {:?}", cluster_hoprd_status.phase, error))
         }
   }

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -1,3 +1,4 @@
+use crate::constants::SupportedReleaseEnum;
 use crate::events::ClusterHoprdEventEnum;
 use crate::hoprd::HoprdSpec;
 use crate::hoprd_deployment_spec::HoprdDeploymentSpec;
@@ -48,6 +49,7 @@ pub struct ClusterHoprdSpec {
     pub config: String,
     pub version: String,
     pub enabled: Option<bool>,
+    pub supported_release: SupportedReleaseEnum,
     pub force_identity_name: Option<bool>,
     pub deployment: Option<HoprdDeploymentSpec>
 }
@@ -352,6 +354,7 @@ impl ClusterHoprd {
             version: self.spec.version.to_owned(),
             deployment: self.spec.deployment.to_owned(),
             identity_pool_name: self.spec.identity_pool_name.to_owned(),
+            supported_release: self.spec.supported_release.to_owned(),
             identity_name
         };
         match self.create_hoprd_resource(context_data.clone(), node_name.to_owned(), hoprd_spec).await {
@@ -422,6 +425,7 @@ impl ClusterHoprd {
             version: self.spec.version.to_owned(),
             deployment: self.spec.deployment.to_owned(),
             identity_pool_name: self.spec.identity_pool_name.to_owned(),
+            supported_release: self.spec.supported_release.to_owned(),
             identity_name: None
         };
         let patch = &Patch::Merge(json!({ "spec": hoprd_spec }));

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,5 +1,6 @@
 // Operator Constants
 pub const RECONCILE_FREQUENCY: u64 = 10;
+pub const RECONCILE_FREQUENCY_ERROR: u64 = 30;
 pub const OPERATOR_ENVIRONMENT: &str = "OPERATOR_ENVIRONMENT";
 pub const OPERATOR_FINALIZER: &str = "hoprds.hoprnet.org/finalizer";
 pub const OPERATOR_JOB_TIMEOUT: u64 = 300;

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,3 +1,6 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
 // Operator Constants
 pub const RECONCILE_FREQUENCY: u64 = 10;
 pub const RECONCILE_FREQUENCY_ERROR: u64 = 30;
@@ -53,3 +56,17 @@ pub const HOPRD_API_HOST: &str = "HOPRD_API_HOST";
 pub const HOPRD_INIT: &str = "HOPRD_INIT";
 pub const HOPRD_HEALTH_CHECK: &str = "HOPRD_HEALTH_CHECK";
 pub const HOPRD_HEALTH_CHECK_HOST: &str = "HOPRD_HEALTH_CHECK_HOST";
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Hash,  Copy, JsonSchema)]
+pub enum SupportedReleaseEnum {
+    #[serde(rename= "providence")]
+    Providence,
+    #[serde(rename= "saint-louis")]
+    SaintLouis 
+}
+
+impl Default for SupportedReleaseEnum {
+    fn default() -> Self {
+        SupportedReleaseEnum::Providence
+    }
+}

--- a/src/context_data.rs
+++ b/src/context_data.rs
@@ -27,8 +27,7 @@ impl ContextData {
     pub async fn new(client: Client) -> Self {
         let operator_environment = env::var(constants::OPERATOR_ENVIRONMENT).unwrap();
         let config_path = if operator_environment.eq("production") {
-            let path = "/app/config/config.yaml".to_owned();
-            path
+            "/app/config/config.yaml".to_owned()
         } else {
             let mut path = env::current_dir().as_ref().unwrap().to_str().unwrap().to_owned();
             path.push_str(&format!("/test-data/sample_config-{operator_environment}.yaml"));
@@ -102,11 +101,11 @@ impl State {
     }
 
     pub fn get_identity_pool(&self, namespace: &String, identity_pool_name: &String) -> Option<Arc<IdentityPool>> {
-        self.identity_pool.get(&format!("{}-{}",namespace, identity_pool_name)).map(|x| x.clone())
+        self.identity_pool.get(&format!("{}-{}",namespace, identity_pool_name)).cloned()
     }
 
     pub fn update_identity_pool(&mut self, identity_pool: IdentityPool) {
-        self.remove_identity_pool(&identity_pool.metadata.namespace.as_ref().unwrap(), &identity_pool.metadata.name.as_ref().unwrap());
+        self.remove_identity_pool(identity_pool.metadata.namespace.as_ref().unwrap(), identity_pool.metadata.name.as_ref().unwrap());
         self.add_identity_pool(identity_pool);
     }
 

--- a/src/controller_cluster.rs
+++ b/src/controller_cluster.rs
@@ -71,7 +71,7 @@ async fn reconciler(
     context: Arc<ContextData>,
 ) -> Result<Action, Error> {
     // Performs action as decided by the `determine_action` function.
-    return match determine_action(&cluster_hoprd) {
+    match determine_action(&cluster_hoprd) {
         ClusterHoprdAction::Create => cluster_hoprd.create(context.clone()).await,
         ClusterHoprdAction::Modify => cluster_hoprd.modify(context.clone()).await,
         ClusterHoprdAction::Delete => cluster_hoprd.delete(context.clone()).await,
@@ -80,7 +80,7 @@ async fn reconciler(
         ClusterHoprdAction::NoOp => Ok(Action::requeue(Duration::from_secs(
             constants::RECONCILE_FREQUENCY,
         ))),
-    };
+    }
 }
 
 /// Actions to be taken when a reconciliation fails - for whatever reason.

--- a/src/controller_cluster.rs
+++ b/src/controller_cluster.rs
@@ -41,7 +41,7 @@ enum ClusterHoprdAction {
 /// # Arguments
 /// - `cluster_hoprd`: A reference to `ClusterHoprd` being reconciled to decide next action upon.
 fn determine_action(cluster_hoprd: &ClusterHoprd) -> ClusterHoprdAction {
-    return if cluster_hoprd.meta().deletion_timestamp.is_some() {
+    return if cluster_hoprd.meta().deletion_timestamp.is_some() && cluster_hoprd.status.is_some() && cluster_hoprd.status.as_ref().unwrap().phase.ne (&ClusterHoprdPhaseEnum::Deleting){
         ClusterHoprdAction::Delete
     } else if cluster_hoprd
         .meta()

--- a/src/controller_hoprd.rs
+++ b/src/controller_hoprd.rs
@@ -45,7 +45,7 @@ enum HoprdAction {
 /// # Arguments
 /// - `hoprd`: A reference to `Hoprd` being reconciled to decide next action upon.
 fn determine_action(hoprd: &Hoprd) -> HoprdAction {
-    return if hoprd.meta().deletion_timestamp.is_some() {
+    return if hoprd.meta().deletion_timestamp.is_some() && hoprd.status.is_some() && hoprd.status.as_ref().unwrap().phase.ne (&HoprdPhaseEnum::Deleting) {
         HoprdAction::Delete
     } else if hoprd.meta().finalizers.as_ref().map_or(true, |finalizers| finalizers.is_empty()) {
         HoprdAction::Create

--- a/src/controller_hoprd.rs
+++ b/src/controller_hoprd.rs
@@ -69,14 +69,14 @@ fn determine_action(hoprd: &Hoprd) -> HoprdAction {
 }
 
 async fn reconciler(hoprd: Arc<Hoprd>, context: Arc<ContextData>) -> Result<Action, Error> {
-    return match determine_action(&hoprd) {
+    match determine_action(&hoprd) {
         HoprdAction::Create => hoprd.create(context.clone()).await,
         HoprdAction::Modify => hoprd.modify(context.clone()).await,
         HoprdAction::Delete => hoprd.delete(context.clone()).await,
         HoprdAction::NoOp => Ok(Action::requeue(Duration::from_secs(
             constants::RECONCILE_FREQUENCY,
         ))),
-    };
+    }
 }
 
 /// Actions to be taken when a reconciliation fails - for whatever reason.

--- a/src/controller_identity.rs
+++ b/src/controller_identity.rs
@@ -64,7 +64,7 @@ async fn reconciler(identity_hoprd: Arc<IdentityHoprd>,context: Arc<ContextData>
     let mut identity_hoprd_cloned = identity_hoprd.clone();
     let identity_hoprd_mutable:  &mut IdentityHoprd = Arc::<IdentityHoprd>::make_mut(&mut identity_hoprd_cloned);
     // Performs action as decided by the `determine_action` function.
-    return match determine_action(&identity_hoprd_mutable) {
+    match determine_action(identity_hoprd_mutable) {
         IdentityHoprdAction::Create => identity_hoprd_mutable.create(context.clone()).await,
         IdentityHoprdAction::Modify => identity_hoprd_mutable.modify(context.clone()).await,
         IdentityHoprdAction::Delete => identity_hoprd_mutable.delete(context.clone()).await,
@@ -72,7 +72,7 @@ async fn reconciler(identity_hoprd: Arc<IdentityHoprd>,context: Arc<ContextData>
         IdentityHoprdAction::NoOp => Ok(Action::requeue(Duration::from_secs(
             constants::RECONCILE_FREQUENCY,
         ))),
-    };
+    }
 }
 
 /// Actions to be taken when a reconciliation fails - for whatever reason.

--- a/src/controller_identity_pool.rs
+++ b/src/controller_identity_pool.rs
@@ -66,7 +66,7 @@ async fn reconciler(identity_pool: Arc<IdentityPool>, context: Arc<ContextData>)
     let mut identity_pool_cloned = identity_pool.clone();
     let identity_pool_mutable:  &mut IdentityPool = Arc::<IdentityPool>::make_mut(&mut identity_pool_cloned);
     // Performs action as decided by the `determine_action` function.
-    return match determine_action(identity_pool_mutable) {
+    match determine_action(identity_pool_mutable) {
         IdentityPoolAction::Create => identity_pool_mutable.create(context.clone()).await,
         IdentityPoolAction::Modify => identity_pool_mutable.modify(context.clone()).await,
         IdentityPoolAction::Sync => identity_pool_mutable.sync(context.clone()).await,
@@ -75,7 +75,7 @@ async fn reconciler(identity_pool: Arc<IdentityPool>, context: Arc<ContextData>)
         IdentityPoolAction::NoOp => Ok(Action::requeue(Duration::from_secs(
             constants::RECONCILE_FREQUENCY,
         ))),
-    };
+    }
 }
 
 /// Actions to be taken when a reconciliation fails - for whatever reason.

--- a/src/events.rs
+++ b/src/events.rs
@@ -106,14 +106,14 @@ impl ResourceEvent for ClusterHoprdEventEnum {
             ClusterHoprdEventEnum::Scaling => Event {
                 type_: EventType::Warning,
                 reason: "Scaling".to_string(),
-                note: Some(format!("ClusterHoprd is scaling")),
+                note: Some("ClusterHoprd is scaling".to_string()),
                 action: "ClusterHoprd is scaling to meet the required replicas".to_string(),
                 secondary: None,
             },
             ClusterHoprdEventEnum::Failed => Event {
                 type_: EventType::Warning,
                 reason: "Failed".to_string(),
-                note: Some(format!("ClusterHoprd is in failed status.")),
+                note: Some("ClusterHoprd is in failed status.".to_string()),
                 action: "ClusterHoprd configuration is corrupted".to_string(),
                 secondary: None,
             },

--- a/src/events.rs
+++ b/src/events.rs
@@ -134,15 +134,15 @@ impl ResourceEvent for ClusterHoprdEventEnum {
             ClusterHoprdEventEnum::CreatingNode => Event {
                 type_: EventType::Normal,
                 reason: "CreatingNode".to_string(),
-                note: Some(format!("Node {} is being created for the cluster", attribute.as_ref().unwrap_or(&"unknown".to_string()))),
-                action: "A new node is being created for the cluster".to_string(),
+                note: Some(format!("Node {} is being created in the cluster", attribute.as_ref().unwrap_or(&"unknown".to_string()))),
+                action: "A new node is being created in the cluster".to_string(),
                 secondary: None,
             },
             ClusterHoprdEventEnum::NodeCreated => Event {
                 type_: EventType::Normal,
                 reason: "NodeCreated".to_string(),
-                note: Some(format!("Node {} is created for the cluster", attribute.as_ref().unwrap_or(&"unknown".to_string()))),
-                action: "A new node is created for the cluster".to_string(),
+                note: Some(format!("Node {} is created in the cluster", attribute.as_ref().unwrap_or(&"unknown".to_string()))),
+                action: "A new node is created in the cluster".to_string(),
                 secondary: None,
             },
             ClusterHoprdEventEnum::DeletingNode => Event {

--- a/src/hoprd.rs
+++ b/src/hoprd.rs
@@ -1,12 +1,11 @@
-use crate::cluster::ClusterHoprdPhaseEnum;
-use crate::events::{HoprdEventEnum, ClusterHoprdEventEnum, IdentityHoprdEventEnum, IdentityPoolEventEnum};
+use crate::events::{HoprdEventEnum,  IdentityHoprdEventEnum, IdentityPoolEventEnum};
 use crate::resource_generics;
 use crate::hoprd_deployment_spec::HoprdDeploymentSpec;
 use crate::identity_hoprd::{IdentityHoprd, IdentityHoprdPhaseEnum};
 use crate::identity_pool::{IdentityPool, IdentityPoolPhaseEnum};
 use crate::model::Error;
 use crate::{
-    cluster::ClusterHoprd, constants, context_data::ContextData, hoprd_deployment, hoprd_ingress,
+    constants, context_data::ContextData, hoprd_deployment, hoprd_ingress,
     hoprd_service
 };
 use chrono::Utc;
@@ -130,7 +129,7 @@ impl Hoprd {
         {
             resource_generics::add_finalizer(client.clone(), self).await;
             let p2p_port = hoprd_ingress::open_port(client.clone(),&hoprd_namespace,&hoprd_name,&context_data.config.ingress).await.unwrap();
-            hoprd_deployment::create_deployment(context_data.clone(),&self,&identity,p2p_port,context_data.config.ingress.to_owned()).await?;
+            hoprd_deployment::create_deployment(context_data.clone(),self,&identity,p2p_port,context_data.config.ingress.to_owned()).await?;
             match self.wait_deployment(client.clone()).await {
                 Ok(()) =>  {
                     hoprd_service::create_service(context_data.clone(), &hoprd_name, &hoprd_namespace, &self.spec.identity_pool_name, p2p_port, owner_reference.to_owned()).await?;
@@ -166,23 +165,20 @@ impl Hoprd {
             }           
             warn!("Detected a change in Hoprd {hoprd_name} while was in Failed phase. Automatically recovering to a Running/Stopped phase");
 
-        } else {
-            if self.annotations().contains_key(constants::ANNOTATION_LAST_CONFIGURATION) {
+        } else  if self.annotations().contains_key(constants::ANNOTATION_LAST_CONFIGURATION) {
                 let previous_hoprd_text: String = self.annotations().get_key_value(constants::ANNOTATION_LAST_CONFIGURATION).unwrap().1.parse().unwrap();
                 match serde_json::from_str::<Hoprd>(&previous_hoprd_text) {
                     Ok(previous_hoprd) => {
                         if self.changed_inmutable_fields(&previous_hoprd.spec) {
                             context_data.send_event(self, HoprdEventEnum::Failed,None).await;
                             self.update_status(client.clone(), HoprdPhaseEnum::Failed, None).await?;
-                        } else {
-                            if let Some(identity) = self.get_identity(client.clone()).await? {
+                        } else if let Some(identity) = self.get_identity(client.clone()).await? {
                                 self.apply_modification(context_data.clone(), &identity).await?;
                             } else {
                                 error!("Hoprd node {hoprd_name} does not have a linked identity and is inconsistent");
                                 context_data.send_event(self, HoprdEventEnum::Failed, None).await;
                                 self.update_status(client.clone(), HoprdPhaseEnum::Failed, None).await?;
                             }
-                        }
                     },
                     Err(_err) => {
                         error!("Could not parse the last applied configuration of Hoprd {hoprd_name}");
@@ -195,7 +191,6 @@ impl Hoprd {
                 context_data.send_event(self, HoprdEventEnum::Failed, None).await;
                 self.update_status(client.clone(), HoprdPhaseEnum::Failed, None).await?;
             }
-        }
         Ok(Action::requeue(Duration::from_secs(constants::RECONCILE_FREQUENCY)))
     }
 
@@ -203,7 +198,7 @@ impl Hoprd {
         let client: Client = context_data.client.clone();
         let hoprd_namespace: String = self.namespace().unwrap();
         let hoprd_name: String = self.name_any();
-        hoprd_deployment::modify_deployment(context_data.clone(), &hoprd_name.to_owned(),&hoprd_namespace.to_owned(),&self.spec.to_owned(),&identity).await?;
+        hoprd_deployment::modify_deployment(context_data.clone(), &hoprd_name.to_owned(),&hoprd_namespace.to_owned(),&self.spec.to_owned(),identity).await?;
         match self.wait_deployment(context_data.client.clone()).await {
             Ok(()) =>  {
                 info!("Hoprd node {hoprd_name} in namespace {hoprd_namespace} has been successfully modified");
@@ -322,17 +317,17 @@ impl Hoprd {
     pub fn get_checksum(&self) -> String {
         let mut hasher: DefaultHasher = DefaultHasher::new();
         self.spec.clone().hash(&mut hasher);
-        return hasher.finish().to_string();
+        hasher.finish().to_string()
     }
 
     async fn get_identity(&self, client: Client) -> Result<Option<IdentityHoprd>, Error> {
         match &self.status {
             Some(status) => {
                 let api: Api<IdentityHoprd> = Api::namespaced(client.clone(), &self.namespace().unwrap());
-                return match status.to_owned().identity_name {
+                match status.to_owned().identity_name {
                     Some(identity_name) => Ok(api.get_opt(identity_name.as_str()).await.unwrap()),
                     None => Ok(None),
-                };
+                }
             }
             None => Ok(None)
         }

--- a/src/hoprd.rs
+++ b/src/hoprd.rs
@@ -1,4 +1,5 @@
 use crate::cluster::{ClusterHoprd, ClusterHoprdPhaseEnum};
+use crate::constants::SupportedReleaseEnum;
 use crate::events::{ClusterHoprdEventEnum, HoprdEventEnum, IdentityHoprdEventEnum, IdentityPoolEventEnum};
 use crate::resource_generics;
 use crate::hoprd_deployment_spec::HoprdDeploymentSpec;
@@ -53,6 +54,7 @@ pub struct HoprdSpec {
     pub version: String,
     pub config: String,
     pub enabled: Option<bool>,
+    pub supported_release: SupportedReleaseEnum,
     pub deployment: Option<HoprdDeploymentSpec>,
 }
 

--- a/src/hoprd_deployment_spec.rs
+++ b/src/hoprd_deployment_spec.rs
@@ -50,7 +50,7 @@ impl Default for HoprdDeploymentSpec {
 
         let default_env = vec!(
             CustomEnvVar::new("RUST_BACKTRACE".to_owned(), "full".to_owned()),
-            CustomEnvVar::new("RUST_LOG".to_owned(), "hoprd=DEBUG".to_owned()),
+            CustomEnvVar::new("RUST_LOG".to_owned(), "info".to_owned()),
             CustomEnvVar::new("DEBUG".to_owned(), "hopr*".to_owned())
         );
         let default_env_string = Some(serde_yaml::to_string(&default_env).unwrap());

--- a/src/hoprd_deployment_spec.rs
+++ b/src/hoprd_deployment_spec.rs
@@ -6,15 +6,15 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
+use crate::constants::SupportedReleaseEnum;
+
 /// Struct to define Pod resources types
 #[derive(Serialize, Debug, Deserialize, PartialEq, Clone, JsonSchema, Hash)]
+#[serde(rename_all = "camelCase")]
 pub struct HoprdDeploymentSpec {
     resources: Option<String>,
-    #[serde(rename(deserialize = "startupProbe"))]
     startup_probe: Option<String>,
-    #[serde(rename(deserialize = "livenessProbe"))]
     liveness_probe: Option<String>,
-    #[serde(rename(deserialize = "readinessProbe"))]
     readiness_probe: Option<String>,
 }
 
@@ -32,19 +32,7 @@ impl Default for HoprdDeploymentSpec {
         })
         .unwrap();
 
-        let default_probe = Probe {
-            http_get: Some(HTTPGetAction {
-                path: Some("/healthcheck/v1/version".to_owned()),
-                port: IntOrString::Int(8080),
-                ..HTTPGetAction::default()
-            }),
-            failure_threshold: Some(6),
-            initial_delay_seconds: Some(30),
-            period_seconds: Some(20),
-            success_threshold: Some(1),
-            timeout_seconds: Some(5),
-            ..Probe::default()
-        };
+        let default_probe = HoprdDeploymentSpec::build_probe("some/path".to_string(), Some(5), Some(1), Some(10));
         let default_probe_string = Some(serde_yaml::to_string(&default_probe).unwrap());
 
         Self {
@@ -61,52 +49,80 @@ impl HoprdDeploymentSpec {
         hoprd_deployment_spec: Option<HoprdDeploymentSpec>,
     ) -> ResourceRequirements {
         let default_deployment_spec = HoprdDeploymentSpec::default();
-        let hoprd_deployment_spec =
-            hoprd_deployment_spec.unwrap_or(default_deployment_spec.clone());
-        let resource_requirements_string = hoprd_deployment_spec
-            .resources
-            .as_ref()
-            .unwrap_or(default_deployment_spec.resources.as_ref().unwrap());
-        let resource_requirements: ResourceRequirements =
-            serde_yaml::from_str(resource_requirements_string).unwrap();
+        let hoprd_deployment_spec = hoprd_deployment_spec.unwrap_or(default_deployment_spec.clone());
+        let resource_requirements_string = hoprd_deployment_spec.resources.as_ref().unwrap_or(default_deployment_spec.resources.as_ref().unwrap());
+        let resource_requirements: ResourceRequirements = serde_yaml::from_str(resource_requirements_string).unwrap();
         resource_requirements
     }
 
-    // pub fn get_liveness_probe(hoprd_deployment_spec: Option<HoprdDeploymentSpec>) -> Probe {
-    //     let default_deployment_spec = HoprdDeploymentSpec::default();
-    //     let hoprd_deployment_spec =
-    //         hoprd_deployment_spec.unwrap_or(default_deployment_spec.clone());
-    //     let liveness_probe_string = hoprd_deployment_spec
-    //         .liveness_probe
-    //         .as_ref()
-    //         .unwrap_or(&default_deployment_spec.liveness_probe.as_ref().unwrap());
-    //     let liveness_probe: Probe = serde_yaml::from_str(liveness_probe_string).unwrap();
-    //     liveness_probe
-    // }
+    pub fn build_probe(path: String, period_seconds: Option<i32>, success_threshold: Option<i32>, failure_threshold: Option<i32>) -> Probe {
+         Probe {
+            http_get: Some(HTTPGetAction {
+                path: Some(path.to_string()),
+                port: IntOrString::Int(3001),
+                ..HTTPGetAction::default()
+            }),
+            timeout_seconds: Some(5),
+            period_seconds,
+            success_threshold,
+            failure_threshold,
+            ..Probe::default()
+        }
+    }
 
-    // pub fn get_startup_probe(hoprd_deployment_spec: Option<HoprdDeploymentSpec>) -> Probe {
-    //     let default_deployment_spec = HoprdDeploymentSpec::default();
-    //     let hoprd_deployment_spec =
-    //         hoprd_deployment_spec.unwrap_or(default_deployment_spec.clone());
-    //     let startup_probe_string = hoprd_deployment_spec
-    //         .startup_probe
-    //         .as_ref()
-    //         .unwrap_or(&default_deployment_spec.startup_probe.as_ref().unwrap());
-    //     let startup_probe: Probe = serde_yaml::from_str(startup_probe_string).unwrap();
-    //     startup_probe
-    // }
+    pub fn get_liveness_probe(supported_release: SupportedReleaseEnum, hoprd_deployment_spec_option: Option<HoprdDeploymentSpec>) -> Option<Probe> {
+        match supported_release {
+            SupportedReleaseEnum::Providence => None,
+            SupportedReleaseEnum::SaintLouis => {
+                let default_liveness_probe = HoprdDeploymentSpec::build_probe("/api/v3/healthyz/".to_owned(),Some(5), Some(1), Some(3));
+                if let Some(hoprd_deployment_spec) = hoprd_deployment_spec_option {
+                    if let Some (liveness_probe_string) = hoprd_deployment_spec.liveness_probe {
+                        Some(serde_yaml::from_str(&liveness_probe_string).unwrap())
+                    } else {
+                        Some(default_liveness_probe)
+                    }
+                } else {
+                    Some(default_liveness_probe)
+                }
+            }
+        }
+    }
 
-    // pub fn get_readiness_probe(hoprd_deployment_spec: Option<HoprdDeploymentSpec>) -> Probe {
-    //     let default_deployment_spec = HoprdDeploymentSpec::default();
-    //     let hoprd_deployment_spec =
-    //         hoprd_deployment_spec.unwrap_or(default_deployment_spec.clone());
-    //     let readiness_probe_string = hoprd_deployment_spec
-    //         .readiness_probe
-    //         .as_ref()
-    //         .unwrap_or(&default_deployment_spec.readiness_probe.as_ref().unwrap());
-    //     let readiness_probe: Probe = serde_yaml::from_str(readiness_probe_string).unwrap();
-    //     readiness_probe
-    // }
+    pub fn get_startup_probe(supported_release: SupportedReleaseEnum, hoprd_deployment_spec_option: Option<HoprdDeploymentSpec>) -> Option<Probe> {
+        match supported_release {
+            SupportedReleaseEnum::Providence => None,
+            SupportedReleaseEnum::SaintLouis => {
+                let default_startup_probe = HoprdDeploymentSpec::build_probe("/api/v3/startedz/".to_owned(),Some(30), Some(1), Some(960));
+                if let Some(hoprd_deployment_spec) = hoprd_deployment_spec_option {
+                    if let Some (startup_probe_string) = hoprd_deployment_spec.startup_probe {
+                        Some(serde_yaml::from_str(&startup_probe_string).unwrap())
+                    } else {
+                        Some(default_startup_probe)
+                    }
+                } else {
+                    Some(default_startup_probe)
+                }
+            }
+        }
+    }
+
+    pub fn get_readiness_probe(supported_release: SupportedReleaseEnum, hoprd_deployment_spec_option: Option<HoprdDeploymentSpec>) -> Option<Probe> {
+        match supported_release {
+            SupportedReleaseEnum::Providence => None,
+            SupportedReleaseEnum::SaintLouis => {
+                let default_readiness_probe = HoprdDeploymentSpec::build_probe("/api/v3/readyz/".to_owned(),Some(30), Some(1), Some(20));
+                if let Some(hoprd_deployment_spec) = hoprd_deployment_spec_option {
+                    if let Some (readiness_probe_string) = hoprd_deployment_spec.readiness_probe {
+                        Some(serde_yaml::from_str(&readiness_probe_string).unwrap())
+                    } else {
+                        Some(default_readiness_probe)
+                    }
+                } else {
+                    Some(default_readiness_probe)
+                }
+            }
+        }
+    }
 }
 #[derive(Serialize, Debug, Deserialize, PartialEq, Clone, JsonSchema, Hash)]
 pub struct EnablingFlag {

--- a/src/hoprd_deployment_spec.rs
+++ b/src/hoprd_deployment_spec.rs
@@ -66,7 +66,7 @@ impl HoprdDeploymentSpec {
         let resource_requirements_string = hoprd_deployment_spec
             .resources
             .as_ref()
-            .unwrap_or(&default_deployment_spec.resources.as_ref().unwrap());
+            .unwrap_or(default_deployment_spec.resources.as_ref().unwrap());
         let resource_requirements: ResourceRequirements =
             serde_yaml::from_str(resource_requirements_string).unwrap();
         resource_requirements

--- a/src/hoprd_service.rs
+++ b/src/hoprd_service.rs
@@ -82,10 +82,10 @@ fn service_ports(p2p_port: i32) -> Vec<ServicePort> {
 ///
 pub async fn delete_service(client: Client, name: &str, namespace: &str) -> Result<(), Error> {
     let api: Api<Service> = Api::namespaced(client, namespace);
-    if let Some(service) = api.get_opt(&name).await? {
+    if let Some(service) = api.get_opt(name).await? {
         let uid = service.metadata.uid.unwrap();
         api.delete(name, &DeleteParams::default()).await?;
-        await_condition(api, &name.to_owned(), conditions::is_deleted(&uid))
+        await_condition(api, name, conditions::is_deleted(&uid))
             .await
             .unwrap();
         Ok(info!("Service {name} successfully deleted"))

--- a/src/identity_hoprd.rs
+++ b/src/identity_hoprd.rs
@@ -115,7 +115,7 @@ impl IdentityHoprd {
         info!("Starting to create identity {identity_name} in namespace {identity_namespace}");
         resource_generics::add_finalizer(client.clone(), self).await;
         self.add_owner_reference(client.clone()).await?;
-        identity_hoprd_persistence::create_pvc(context_data.clone(), &self).await?;
+        identity_hoprd_persistence::create_pvc(context_data.clone(), self).await?;
         context_data.send_event(self, IdentityHoprdEventEnum::Initialized, None).await;
         self.update_phase(client.clone(), IdentityHoprdPhaseEnum::Initialized, None).await?;
         // TODO: Validate data
@@ -241,7 +241,7 @@ impl IdentityHoprd {
     pub fn get_checksum(&self) -> String {
         let mut hasher: DefaultHasher = DefaultHasher::new();
         self.spec.clone().hash(&mut hasher);
-        return hasher.finish().to_string();
+        hasher.finish().to_string()
     }
 
     /// Updates the status of IdentityHoprd
@@ -271,7 +271,7 @@ impl IdentityHoprd {
 
     pub async fn get_identity_pool(&self, client: Client) -> Result<IdentityPool, Error> {
         let api: Api<IdentityPool> = Api::namespaced(client.clone(), &self.namespace().unwrap());
-        return Ok(api.get(&self.spec.identity_pool_name).await.unwrap());
+        Ok(api.get(&self.spec.identity_pool_name).await.unwrap())
     }
 
     // Unlocks a given identity from a Hoprd node

--- a/src/identity_hoprd.rs
+++ b/src/identity_hoprd.rs
@@ -137,11 +137,12 @@ impl IdentityHoprd {
                 updated = true;
             }
         }
-        context_data.send_event(&self.get_identity_pool(client.clone()).await.unwrap(), IdentityPoolEventEnum::IdentityCreated, Some(identity_name)).await;
+        context_data.send_event(&self.get_identity_pool(client.clone()).await.unwrap(), IdentityPoolEventEnum::IdentityCreated, Some(identity_name.to_owned())).await;
         if updated {
             // These instructions need to be done out of the context_data lock
             context_data.send_event(self, IdentityHoprdEventEnum::Ready, None).await;
             self.update_phase(client.clone(), IdentityHoprdPhaseEnum::Ready, None).await?;
+            info!("IdentityHoprd {identity_name} in namespace {identity_namespace} successfully created");
         } else {
             error!("Identity pool {} not exists in namespace {}", identity_pool_name, &self.namespace().unwrap());
         }

--- a/src/identity_hoprd.rs
+++ b/src/identity_hoprd.rs
@@ -135,7 +135,7 @@ impl IdentityHoprd {
             if identity_pool_option.is_some() {
                 let mut identity_pool_arc = identity_pool_option.unwrap();
                 let identity_pool:  &mut IdentityPool = Arc::<IdentityPool>::make_mut(&mut identity_pool_arc);
-                identity_pool.update_phase(context_data.client.clone(), IdentityPoolPhaseEnum::IdentityCreated).await?;
+                identity_pool.update_status(context_data.client.clone(), IdentityPoolPhaseEnum::IdentityCreated).await?;
                 context_state.update_identity_pool(identity_pool.to_owned());
                 updated = true;
             }
@@ -208,7 +208,7 @@ impl IdentityHoprd {
                     if identity_pool_option.is_some() {
                         let mut identity_pool_arc = identity_pool_option.unwrap();
                         let identity_pool:  &mut IdentityPool = Arc::<IdentityPool>::make_mut(&mut identity_pool_arc);
-                        identity_pool.update_phase(context_data.client.clone(), IdentityPoolPhaseEnum::IdentityDeleted).await?;
+                        identity_pool.update_status(context_data.client.clone(), IdentityPoolPhaseEnum::IdentityDeleted).await?;
                         context_state.update_identity_pool(identity_pool.to_owned());
                     } else {
                         warn!("Identity pool {} not exists in namespace {}", &self.spec.identity_pool_name, &self.namespace().unwrap());
@@ -289,7 +289,7 @@ impl IdentityHoprd {
                 let mut context_state = context_data.state.write().await;
                 let mut identity_pool_arc = context_state.get_identity_pool(&self.namespace().unwrap(), &self.spec.identity_pool_name).unwrap();
                 let identity_pool:  &mut IdentityPool = Arc::<IdentityPool>::make_mut(&mut identity_pool_arc);
-                identity_pool.update_phase(context_data.client.clone(), IdentityPoolPhaseEnum::Unlocked).await?;
+                identity_pool.update_status(context_data.client.clone(), IdentityPoolPhaseEnum::Unlocked).await?;
                 context_state.update_identity_pool(identity_pool.to_owned());
             }
             context_data.send_event(&self.get_identity_pool(context_data.client.clone()).await.unwrap(), IdentityPoolEventEnum::Unlocked, Some(self.name_any())).await;

--- a/src/identity_pool.rs
+++ b/src/identity_pool.rs
@@ -539,7 +539,7 @@ impl IdentityPool {
                             name: "kubectl".to_owned(),
                             image: Some("registry.hub.docker.com/bitnami/kubectl:1.24".to_owned()),
                             image_pull_policy: Some("IfNotPresent".to_owned()),
-                            command: Some(vec!["/bin/bash".to_owned(), "-c".to_owned()]),
+                            command: Some(vec!["/bin/sh".to_owned(), "-c".to_owned()]),
                             args: Some(create_resource_args),
                             env: Some(env_vars),
                             volume_mounts: Some(volume_mounts),

--- a/src/identity_pool_cronjob_faucet.rs
+++ b/src/identity_pool_cronjob_faucet.rs
@@ -42,7 +42,7 @@ pub async fn create_cron_job(context_data: Arc<ContextData>, identity_pool: &Ide
             schedule: identity_pool.spec.funding.to_owned().unwrap().schedule,
             job_template: JobTemplateSpec {
                 metadata: Some(ObjectMeta::default()),
-                spec: Some(get_job_template(context_data.clone(), &identity_pool).await),
+                spec: Some(get_job_template(context_data.clone(), identity_pool).await),
             },
             ..CronJobSpec::default()
         }),
@@ -110,8 +110,7 @@ async fn get_job_template(context_data: Arc<ContextData>, identity_pool: &Identi
                     volumes: Some(volumes),
                     restart_policy: Some("Never".to_owned()),
                 ..PodSpec::default()
-                }),
-            ..PodTemplateSpec::default()
+                })
             },
         ..JobSpec::default()
     }
@@ -168,10 +167,10 @@ pub async fn modify_cron_job(client: Client, identity_pool: &IdentityPool) -> Re
 /// Deletes an existing CronJob.
 pub async fn delete_cron_job(client: Client, name: &str,namespace: &str) -> Result<(), Error> {
     let api: Api<CronJob> = Api::namespaced(client, namespace);
-    if let Some(create_cron_job) = api.get_opt(&name).await? {
+    if let Some(create_cron_job) = api.get_opt(name).await? {
         let uid = create_cron_job.metadata.uid.unwrap();
         api.delete(name, &DeleteParams::default()).await?;
-        await_condition(api, &name.to_owned(), conditions::is_deleted(&uid))
+        await_condition(api, name, conditions::is_deleted(&uid))
             .await
             .unwrap();
         Ok(info!("CronJob {name} successfully deleted"))

--- a/src/identity_pool_cronjob_faucet.rs
+++ b/src/identity_pool_cronjob_faucet.rs
@@ -59,7 +59,7 @@ pub async fn create_cron_job(context_data: Arc<ContextData>, identity_pool: &Ide
 async fn build_args_line(identity_pool: &IdentityPool) -> Option<Vec<String>> {
     let native_amount: String =identity_pool.spec.funding.clone().unwrap().native_amount.to_string();
     let network: String = identity_pool.spec.network.to_owned();
-    let command_line: String = format!("PATH=${{PATH}}:/app/hoprnet/.foundry/bin/ /bin/hopli faucet --network {} --contracts-root /app/hoprnet/packages/ethereum/contracts/ --hopr-amount 0 --native-amount \"{}\" --address $(cat /data/addresses.txt)", network, native_amount);
+    let command_line: String = format!("PATH=${{PATH}}:/app/hoprnet/.foundry/bin/ /bin/hopli faucet --network {} --contracts-root /app/hoprnet/ethereum/contracts/ --hopr-amount 0 --native-amount \"{}\" --address $(cat /data/addresses.txt)", network, native_amount);
     Some(vec![command_line])
 }
 

--- a/src/identity_pool_service_account.rs
+++ b/src/identity_pool_service_account.rs
@@ -25,7 +25,7 @@ pub async fn create_rbac(
     Ok(())
 }
 
-pub async fn delete_rbac(client: Client, namespace: &String, name: &String) -> Result<(), Error> {
+pub async fn delete_rbac(client: Client, namespace: &str, name: &str) -> Result<(), Error> {
     delete_service_account(client.clone(), namespace, name).await?;
     delete_role(client.clone(), namespace, name).await?;
     delete_role_binding(client.clone(), namespace, name).await?;
@@ -123,10 +123,10 @@ async fn create_role_binding(context_data: Arc<ContextData>, namespace: &String,
 
 async fn delete_service_account(client: Client, name: &str, namespace: &str) -> Result<(), Error> {
     let api: Api<ServiceAccount> = Api::namespaced(client, namespace);
-    if let Some(service_account) = api.get_opt(&name).await? {
+    if let Some(service_account) = api.get_opt(name).await? {
         let uid = service_account.metadata.uid.unwrap();
         api.delete(name, &DeleteParams::default()).await?;
-        await_condition(api, &name.to_owned(), conditions::is_deleted(&uid))
+        await_condition(api, name, conditions::is_deleted(&uid))
             .await
             .unwrap();
         Ok(info!("ServiceAccount {name} successfully deleted"))
@@ -139,10 +139,10 @@ async fn delete_service_account(client: Client, name: &str, namespace: &str) -> 
 
 async fn delete_role(client: Client, name: &str, namespace: &str) -> Result<(), Error> {
     let api: Api<Role> = Api::namespaced(client, namespace);
-    if let Some(role) = api.get_opt(&name).await? {
+    if let Some(role) = api.get_opt(name).await? {
         let uid = role.metadata.uid.unwrap();
         api.delete(name, &DeleteParams::default()).await?;
-        await_condition(api, &name.to_owned(), conditions::is_deleted(&uid))
+        await_condition(api, name, conditions::is_deleted(&uid))
             .await
             .unwrap();
         Ok(info!("Role {name} successfully deleted"))
@@ -155,10 +155,10 @@ async fn delete_role(client: Client, name: &str, namespace: &str) -> Result<(), 
 
 async fn delete_role_binding(client: Client, name: &str, namespace: &str) -> Result<(), Error> {
     let api: Api<RoleBinding> = Api::namespaced(client, namespace);
-    if let Some(role_binding) = api.get_opt(&name).await? {
+    if let Some(role_binding) = api.get_opt(name).await? {
         let uid = role_binding.metadata.uid.unwrap();
         api.delete(name, &DeleteParams::default()).await?;
-        await_condition(api, &name.to_owned(), conditions::is_deleted(&uid))
+        await_condition(api, name, conditions::is_deleted(&uid))
             .await
             .unwrap();
         Ok(info!("RoleBinding {name} successfully deleted"))

--- a/src/identity_pool_service_monitor.rs
+++ b/src/identity_pool_service_monitor.rs
@@ -90,8 +90,7 @@ pub async fn create_service_monitor(context_data: Arc<ContextData>, name: &str, 
 }
 
 pub fn build_metric_relabel() -> Vec<ServiceMonitorEndpointsRelabelings> {
-    let mut metrics = Vec::with_capacity(2);
-    metrics.push(ServiceMonitorEndpointsRelabelings {
+    vec![ServiceMonitorEndpointsRelabelings {
         action: Some(ServiceMonitorEndpointsRelabelingsAction::Replace),
         source_labels: Some(vec![
             "__meta_kubernetes_pod_label_hoprds_hoprnet_org_network".to_owned(),
@@ -101,8 +100,7 @@ pub fn build_metric_relabel() -> Vec<ServiceMonitorEndpointsRelabelings> {
         regex: None,
         replacement: None,
         separator: None,
-    });
-    metrics.push(ServiceMonitorEndpointsRelabelings {
+    }, ServiceMonitorEndpointsRelabelings {
         action: Some(ServiceMonitorEndpointsRelabelingsAction::Replace),
         source_labels: Some(vec![
             "__meta_kubernetes_pod_label_app_kubernetes_io_instance".to_owned(),
@@ -112,8 +110,7 @@ pub fn build_metric_relabel() -> Vec<ServiceMonitorEndpointsRelabelings> {
         regex: None,
         replacement: None,
         separator: None,
-    });
-    metrics.push(ServiceMonitorEndpointsRelabelings {
+    }, ServiceMonitorEndpointsRelabelings {
         action: Some(ServiceMonitorEndpointsRelabelingsAction::Replace),
         source_labels: Some(vec![
             "__meta_kubernetes_pod_label_app_kubernetes_io_instance".to_owned(),
@@ -123,8 +120,7 @@ pub fn build_metric_relabel() -> Vec<ServiceMonitorEndpointsRelabelings> {
         regex: None,
         replacement: None,
         separator: None,
-    });
-    metrics.push(ServiceMonitorEndpointsRelabelings {
+    }, ServiceMonitorEndpointsRelabelings {
         action: Some(ServiceMonitorEndpointsRelabelingsAction::Replace),
         source_labels: Some(vec![
             "__meta_kubernetes_pod_label_hoprds_hoprnet_org_safe_address".to_owned(),
@@ -134,8 +130,7 @@ pub fn build_metric_relabel() -> Vec<ServiceMonitorEndpointsRelabelings> {
         regex: None,
         replacement: None,
         separator: None,
-    });
-    metrics.push(ServiceMonitorEndpointsRelabelings {
+    }, ServiceMonitorEndpointsRelabelings {
         action: Some(ServiceMonitorEndpointsRelabelingsAction::Replace),
         source_labels: Some(vec![
             "__meta_kubernetes_pod_label_hoprds_hoprnet_org_module_address".to_owned(),
@@ -145,8 +140,7 @@ pub fn build_metric_relabel() -> Vec<ServiceMonitorEndpointsRelabelings> {
         regex: None,
         replacement: None,
         separator: None,
-    });
-    metrics.push(ServiceMonitorEndpointsRelabelings {
+    }, ServiceMonitorEndpointsRelabelings {
         action: Some(ServiceMonitorEndpointsRelabelingsAction::Replace),
         source_labels: Some(vec![
             "__meta_kubernetes_pod_label_hoprds_hoprnet_org_address".to_owned(),
@@ -156,8 +150,7 @@ pub fn build_metric_relabel() -> Vec<ServiceMonitorEndpointsRelabelings> {
         regex: None,
         replacement: None,
         separator: None,
-    });
-    metrics.push(ServiceMonitorEndpointsRelabelings {
+    }, ServiceMonitorEndpointsRelabelings {
         action: Some(ServiceMonitorEndpointsRelabelingsAction::Replace),
         source_labels: Some(vec![
             "__meta_kubernetes_pod_label_hoprds_hoprnet_org_peerId".to_owned(),
@@ -167,17 +160,16 @@ pub fn build_metric_relabel() -> Vec<ServiceMonitorEndpointsRelabelings> {
         regex: None,
         replacement: None,
         separator: None,
-    });
-    metrics
+    }]
 }
 
 /// Deletes an existing serviceMonitor.
 pub async fn delete_service_monitor(client: Client, name: &str,namespace: &str) -> Result<(), Error> {
     let api: Api<ServiceMonitor> = Api::namespaced(client, namespace);
-    if let Some(service_monitor) = api.get_opt(&name).await? {
+    if let Some(service_monitor) = api.get_opt(name).await? {
         let uid = service_monitor.metadata.uid.unwrap();
         api.delete(name, &DeleteParams::default()).await?;
-        await_condition(api, &name.to_owned(), conditions::is_deleted(&uid))
+        await_condition(api, name, conditions::is_deleted(&uid))
             .await
             .unwrap();
         Ok(info!("ServiceMonitor {name} successfully deleted"))

--- a/src/resource_generics.rs
+++ b/src/resource_generics.rs
@@ -35,7 +35,7 @@ pub async fn delete_finalizer<K : kube::Resource<Scope = NamespaceResourceScope,
              "finalizers": null
          }
      }));
-     if let Some(_) = api.get_opt(&name).await.unwrap_or(None) {
+     if api.get_opt(&name).await.unwrap_or(None).is_some() {
          match api.patch(&name, &PatchParams::default(), &patch).await
          {
              Ok(_hopr) => (),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -4,17 +4,11 @@ use std::collections::BTreeMap;
 pub fn common_lables(name: String, instance: Option<String>, component: Option<String>) -> BTreeMap<String, String> {
     let mut labels: BTreeMap<String, String> = BTreeMap::new();
     labels.insert(constants::LABEL_KUBERNETES_NAME.to_owned(), name);
-    match instance {
-        Some(instance) => {
-            labels.insert(constants::LABEL_KUBERNETES_INSTANCE.to_owned(), instance);
-        }
-        None => {}
+    if let Some(instance) = instance {
+        labels.insert(constants::LABEL_KUBERNETES_INSTANCE.to_owned(), instance);
     }
-    match component {
-        Some(component) => {
-            labels.insert(constants::LABEL_KUBERNETES_COMPONENT.to_owned(), component);
-        }
-        None => {}
+    if let Some(component) = component {
+        labels.insert(constants::LABEL_KUBERNETES_COMPONENT.to_owned(), component);
     }
-    return labels;
+    labels
 }

--- a/test-data/clean-node-db.yaml
+++ b/test-data/clean-node-db.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: testing-pod
+  namespace:  hoprd-operator
+spec:
+  containers:
+  - image: ubuntu:latest
+    name: hoprd
+    command:
+    - /bin/sh
+    - -c
+    args:
+    - rm -rf /app/*
+    resources:
+      limits:
+        cpu: 500m
+        memory: 1000Mi
+      requests:
+        cpu: 100m
+        memory: 100Mi
+    volumeMounts:
+    - mountPath: /app
+      name: hoprd-data
+  volumes:
+  - name: hoprd-data
+    persistentVolumeClaim:
+      claimName: identity-pool-hoprd-operator-1 
+    

--- a/test-data/cluster-hoprd-providence.yaml
+++ b/test-data/cluster-hoprd-providence.yaml
@@ -8,8 +8,9 @@ metadata:
   namespace:  hoprd-operator
 spec:
   identityPoolName: identity-pool-hoprd-operator
-  replicas: 2
+  replicas: 1
   version: 2.0.7
+  supportedRelease: providence
   enabled: true
   config: |
     host:

--- a/test-data/cluster-hoprd-saint-louis.yaml
+++ b/test-data/cluster-hoprd-saint-louis.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: hoprnet.org/v1alpha2
+kind: ClusterHoprd
+metadata:
+  name: pr-1234
+  labels:
+    hoprds.hoprnet.org/pullRequest: "1234"
+  namespace:  hoprd-operator
+spec:
+  identityPoolName: identity-pool-hoprd-operator
+  replicas: 1
+  version: saint-louis-latest
+  supportedRelease: saint-louis
+  enabled: true
+  config: |
+    hopr:
+      chain:
+        announce: true
+        network: doufur
+        provider: https://rpc.ankr.com/gnosis

--- a/test-data/cluster-hoprd.yaml
+++ b/test-data/cluster-hoprd.yaml
@@ -8,84 +8,21 @@ metadata:
   namespace:  hoprd-operator
 spec:
   identityPoolName: identity-pool-hoprd-operator
-  replicas: 1
-  version: latest
+  replicas: 2
+  version: 2.0.7
   enabled: true
   config: |
-    hopr:
-      host:
-        address: !IPv4 0.0.0.0
-        port: 9091
-      db:
-        data: "/app/hoprd-db"
-        initialize: true
-        force_initialize: false
-      strategy:
-        on_fail_continue: true
-        allow_recursive: false
-        finalize_channel_closure: true
-        strategies:
-          - !Promiscuous
-            max_channels: 10
-            network_quality_threshold: 0.5
-            new_channel_stake: "1000000 HOPR"
-            minimum_node_balance: "10000000 HOPR"
-            min_network_size_samples: 20
-            enforce_max_channels: true
-          - !AutoFunding
-            funding_amount: "1000000 HOPR"
-            min_stake_threshold: "100000 HOPR"
-          - !Aggregating
-            aggregation_threshold: 1000000
-            unrealized_balance_ratio: 0.9
-            aggregation_timeout: 60
-            aggregate_on_channel_close: true
-          - !AutoRedeeming
-            redeem_only_aggregated: True
-      heartbeat:
-        variance: 2000
-        interval: 20000
-        threshold: 60000
-      network_options:
-        min_delay: 1
-        max_delay: 300
-        quality_avg_window_size: 25
-        quality_bad_threshold: 0.2
-        quality_offline_threshold: 0.5
-        quality_step: 0.1
-        ignore_timeframe: 600
-        backoff_exponent: 1.5
-        backoff_min: 2
-        backoff_max: 300
-      healthcheck:
-        enable: true
-        host: 0.0.0.0
-        port: 8080
-      transport:
-        announce_local_addresses: false
-        prefer_local_addresses: false
-      protocol:
-        ack:
-          timeout: 15
-        heartbeat:
-          timeout: 15
-        msg:
-          timeout: 15
-        ticket_aggregation:
-          timeout: 15
-      chain:
-        network: rotsee
-        announce: true
-        provider:
-        check_unrealized_balance: true
-      safe_module:
-        safe_transaction_service_provider: https://safe-transaction.prod.hoprtech.net/
-        safe_address: "0x0000000000000000000000000000000000000000"
-        module_address: "0x0000000000000000000000000000000000000000"
+    host:
+      address: !IPv4 0.0.0.0
+      port: 9091
     identity:
       file: "/app/hoprd-db/.hoprd.id"
-      password: "<READCTED>"
+      password: "<REDACTED_PASS>"
       private_key:
+    db:
+      data: "/app/hoprd-db"
+      initialize: true
+      force_initialize: false
     inbox:
       capacity: 512
       max_age: 900
@@ -93,9 +30,95 @@ spec:
       - 0
     api:
       enable: true
-      auth: !Token "<READCTED>"
+      auth: !Token "<REDACTED>"
       host:
         address: !IPv4 0.0.0.0
         port: 3001
+    strategy:
+      on_fail_continue: true
+      allow_recursive: false
+      finalize_channel_closure: true
+      strategies:
+    heartbeat:
+      variance: 2000
+      interval: 20000
+      threshold: 60000
+    network_options:
+      min_delay: 1
+      max_delay: 300
+      quality_avg_window_size: 25
+      quality_bad_threshold: 0.2
+      quality_offline_threshold: 0.5
+      quality_step: 0.1
+      ignore_timeframe: 600
+      backoff_exponent: 1.5
+      backoff_min: 2
+      backoff_max: 300
+    healthcheck:
+      enable: true
+      host: 0.0.0.0
+      port: 8080
+    protocol:
+      ack:
+        timeout: 15
+      heartbeat:
+        timeout: 15
+      msg:
+        timeout: 15
+      ticket_aggregation:
+        timeout: 15
+    network: rotsee
+    chain:
+      announce: true
+      provider: https://rpc.ankr.com/gnosis
+      check_unrealized_balance: true
+    safe_module:
+      safe_transaction_service_provider:
+      safe_address:
+        addr:
+          - 44
+          - 44
+          - 44
+          - 44
+          - 44
+          - 44
+          - 44
+          - 44
+          - 44
+          - 44
+          - 44
+          - 44
+          - 44
+          - 44
+          - 44
+          - 44
+          - 44
+          - 44
+          - 44
+          - 44
+      module_address:
+        addr:
+          - 44
+          - 44
+          - 44
+          - 44
+          - 44
+          - 44
+          - 44
+          - 44
+          - 44
+          - 44
+          - 44
+          - 44
+          - 44
+          - 44
+          - 44
+          - 44
+          - 44
+          - 44
+          - 44
+          - 44
     test:
+      announce_local_addresses: false
+      prefer_local_addresses: false
       use_weak_crypto: false

--- a/test-data/hoprd-config-template.yaml
+++ b/test-data/hoprd-config-template.yaml
@@ -1,0 +1,68 @@
+---
+
+hopr:
+  host:
+    address: !IPv4 0.0.0.0
+    port: 9091
+  db:
+    data: "/app/hoprd-db"
+    initialize: true
+    force_initialize: false
+  strategy:
+    on_fail_continue: true
+    allow_recursive: false
+    finalize_channel_closure: false
+    strategies:
+  heartbeat:
+    variance: 2       # CHANGE: now in seconds
+    interval: 20      # CHANGE: now in seconds
+    threshold: 60     # CHANGE: now in seconds
+  network_options:
+    min_delay: 1
+    max_delay: 300
+    quality_bad_threshold: 0.2
+    quality_offline_threshold: 0.5
+    quality_step: 0.1
+    quality_avg_window_size: 25
+    ignore_timeframe: 600
+    backoff_exponent: 1.5
+    backoff_min: 2.0
+    backoff_max: 300.0
+  transport:          # CHANGE: new key with values previously in the `test` key
+    announce_local_addresses: false
+    prefer_local_addresses: false
+  protocol:
+    ack:
+      timeout: 15
+    heartbeat:
+      timeout: 15
+    msg:
+      timeout: 15
+    ticket_aggregation:
+      timeout: 15
+  chain:
+    announce: false
+    network: doufur       # CHANGE: Contains the target network now, moved form the 'network' key
+    provider: null
+    check_unrealized_balance: true
+  safe_module:
+    safe_transaction_service_provider: https://safe-transaction.stage.hoprtech.net/
+    safe_address: '0x0000000000000000000000000000000000000000'      # CHANGE: a hex string now
+    module_address: '0x0000000000000000000000000000000000000000'    # CHANGE: a hex string now
+identity:
+  file: "/app/hoprd-db/.hoprd.id"
+  password: "<REDACTED>"
+  private_key:
+inbox:
+  capacity: 512
+  max_age: 900
+  excluded_tags:
+  - 0
+api:
+  enable: true
+  auth: !Token "<REDACTED>"
+  host:
+    address: !IPv4 0.0.0.0
+    port: 3001
+test:       # CHANGE: Some options moved to 'hopr.transport'
+  use_weak_crypto: false


### PR DESCRIPTION
- Fixes the scale down of nodes
- Hopli uses the new contractsroot folder
- Use clipper to lint Rust code
- When the user modifies the field `enabled` on a ClusterHoprd resource, it does not perform any action.
- Rename the field ClusterHoprd.status.runningNodes to ClusterHoprd.status.currentNodes to reflect the created nodes and independently if they are running or not, because that information is linked only at the Hoprd resource.
- On the IdentityPool creation, check if the wallet exists, otherwise sleep
- On the IdentityHoprd creation, check if the IdentityPool exists, otherwise sleep
- Adding specification of custom environment variables

Migration procedure
```
export ENVIRONMENT_NAME=prod
kubectl patch Applications -n argocd apps-${ENVIRONMENT_NAME} --type=json -p="[{'op': 'remove', 'path': '/spec/syncPolicy/automated'}]"
kubectl patch Applications -n argocd hoprd-operator-app --type=json -p="[{'op': 'remove', 'path': '/spec/syncPolicy/automated'}]"
kubectl patch Applications -n argocd hoprd-nodes-app --type=json -p="[{'op': 'remove', 'path': '/spec/syncPolicy/automated'}]"
kubectl patch Applications -n argocd network-dashboard-app --type=json -p="[{'op': 'remove', 'path': '/spec/syncPolicy/automated'}]"
kubectl patch --context kubernetes-admin@cluster.prod cronjobs -n network-dashboard network-dashboard-update-peers -p '{"spec" : {"suspend" : true }}'
kubectl patch -n argocd applications hoprd-operator-app --type='json' -p='[{"op": "replace", "path": "/spec/source/targetRevision", "value": "ausias/update-operator"}]'
kubectl scale deployment -n hoprd-operator hoprd-operator-controller --replicas=0

for record in `kubectl get -A ClusterHoprd -o jsonpath="{range .items[*]}{.metadata.namespace}{'_'}{.metadata.name}{' '}{end}"`; do echo "kubectl patch ClusterHoprd -n ${record/_/ } --type='json' -p='[{\"op\": \"add\", \"path\": \"/spec/supportedRelease\", \"value\": \"providence\"},{\"op\": \"add\", \"path\": \"/status/currentNodes\", \"value\": 0}]'"; done

for record in `kubectl get -A Hoprd -o jsonpath="{range .items[*]}{.metadata.namespace}{'_'}{.metadata.name}{' '}{end}"`; do echo "kubectl patch Hoprd -n ${record/_/ } --type='json' -p='[{\"op\": \"add\", \"path\": \"/spec/supportedRelease\", \"value\": \"providence\"}]'"; done 

kubectl patch -n ctdapp ClusterHoprd ctdapp-production --type='json' -p='[{"op": "add", "path": "/status/currentNodes", "value":5}]'
kubectl patch -n rotsee ClusterHoprd ctdapp-staging --type='json' -p='[{"op": "add", "path": "/status/currentNodes", "value":5}]'
kubectl patch -n dufour ClusterHoprd core-dufour-providence --type='json' -p='[{"op": "add", "path": "/status/currentNodes", "value":5}]'
kubectl patch -n rotsee ClusterHoprd core-rotsee-saint-louis --type='json' -p='[{"op": "add", "path": "/status/currentNodes", "value":0}]'
kubectl patch -n network-dashboard ClusterHoprd network-dashboard --type='json' -p='[{"op": "add", "path": "/status/currentNodes", "value":4}]'
kubectl patch -n ctdapp ClusterHoprd ctdapp-production --type='json' -p='[{"op": "remove", "path": "/status/currentNodes"}]'
kubectl patch -n rotsee ClusterHoprd ctdapp-staging --type='json' -p='[{"op": "remove", "path": "/status/currentNodes"}]'
kubectl patch -n dufour ClusterHoprd core-dufour-providence --type='json' -p='[{"op": "remove", "path": "/status/currentNodes"}]'
kubectl patch -n rotsee ClusterHoprd core-rotsee-saint-louis --type='json' -p='[{"op": "remove", "path": "/status/currentNodes"}]'
kubectl patch -n network-dashboard ClusterHoprd network-dashboard --type='json' -p='[{"op": "remove", "path": "/status/currentNodes"}]'

kubectl scale deployment -n hoprd-operator hoprd-operator-controller --replicas=1

- Modify each ClusterHoprd by setting a different config.identity.password dummy value
- Delete each Hoprd resource to recreate all sub-resources with the new version of the Operator
- Check the status of the deployments

kubectl patch -n argocd applications hoprd-nodes-app --type='json' -p='[{"op": "replace", "path": "/spec/source/targetRevision", "value": "ausias/update-operator"}]'

cd ../hoprd-operator &&  gh pr merge 185 
cd ../hoprd-nodes &&  gh pr merge 14
cd ../gitops &&  gh pr merge 81


export PATCH_ENABLE_SYNC="{\"spec\":{\"syncPolicy\":{\"automated\": {}}}}"
kubectl patch Applications -n argocd network-dashboard-app --type merge --patch "${PATCH_ENABLE_SYNC}"
kubectl patch Applications -n argocd hoprd-operator-app --type merge --patch "${PATCH_ENABLE_SYNC}"
kubectl patch Applications -n argocd hoprd-nodes-app --type merge --patch "${PATCH_ENABLE_SYNC}"
kubectl patch Applications -n argocd apps-${ENVIRONMENT_NAME} --type merge --patch "${PATCH_ENABLE_SYNC}"

```