### PR TITLE
Allow to delete database on changing field "deleteDatabase"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -526,7 +526,7 @@ dependencies = [
 
 [[package]]
 name = "hoprd_operator"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "async-recursion",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hoprd_operator"
-version = "0.2.12"
+version = "0.2.13"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2021"
 

--- a/charts/hoprd-operator/Chart.yaml
+++ b/charts/hoprd-operator/Chart.yaml
@@ -2,8 +2,8 @@
 
 apiVersion: v2
 name: hoprd-operator
-version: 0.2.8
-appVersion: 0.2.11
+version: 0.2.9
+appVersion: 0.2.13
 description: A Helm chart operator for managing Hopr nodes
 type: application
 icon: "https://hoprnet.org/assets/icons/logo.svg"

--- a/charts/hoprd-operator/templates/crd-hoprd.yaml
+++ b/charts/hoprd-operator/templates/crd-hoprd.yaml
@@ -89,6 +89,9 @@ spec:
                 version:
                   type: string
                   description: 'An specific hoprd version. Should match with a docker tag'
+                deleteDatabase:
+                  type: boolean
+                  description: 'Trigger to delete the database of the node'
               required: 
                 - version
                 - identityPoolName

--- a/src/cluster/cluster_hoprd.rs
+++ b/src/cluster/cluster_hoprd.rs
@@ -354,6 +354,7 @@ impl ClusterHoprd {
             deployment: self.spec.deployment.to_owned(),
             identity_pool_name: self.spec.identity_pool_name.to_owned(),
             supported_release: self.spec.supported_release.to_owned(),
+            delete_database: Some(false),
             identity_name
         };
         match self.create_hoprd_resource(context_data.clone(), node_name.to_owned(), hoprd_spec).await {
@@ -424,6 +425,7 @@ impl ClusterHoprd {
             enabled: self.spec.enabled,
             version: self.spec.version.to_owned(),
             deployment: self.spec.deployment.to_owned(),
+            delete_database: Some(false),
             identity_pool_name: self.spec.identity_pool_name.to_owned(),
             supported_release: self.spec.supported_release.to_owned(),
             identity_name: None

--- a/src/hoprd/hoprd_controller.rs
+++ b/src/hoprd/hoprd_controller.rs
@@ -69,10 +69,13 @@ fn determine_action(hoprd: &Hoprd) -> HoprdAction {
 }
 
 async fn reconciler(hoprd: Arc<Hoprd>, context: Arc<ContextData>) -> Result<Action, Error> {
-    match determine_action(&hoprd) {
-        HoprdAction::Create => hoprd.create(context.clone()).await,
-        HoprdAction::Modify => hoprd.modify(context.clone()).await,
-        HoprdAction::Delete => hoprd.delete(context.clone()).await,
+    let mut hoprd_cloned = hoprd.clone();
+    let hoprd_mutable:  &mut Hoprd = Arc::<Hoprd>::make_mut(&mut hoprd_cloned);
+    // Performs action as decided by the `determine_action` function.
+    match determine_action(hoprd_mutable) {
+        HoprdAction::Create => hoprd_mutable.create(context.clone()).await,
+        HoprdAction::Modify => hoprd_mutable.modify(context.clone()).await,
+        HoprdAction::Delete => hoprd_mutable.delete(context.clone()).await,
         HoprdAction::NoOp => Ok(Action::requeue(Duration::from_secs(
             constants::RECONCILE_SHORT_FREQUENCY,
         ))),

--- a/test-data/hoprd-node-core.yaml
+++ b/test-data/hoprd-node-core.yaml
@@ -3,97 +3,21 @@ apiVersion: hoprnet.org/v1alpha2
 kind: Hoprd
 metadata:
   name: core-rotsee-1
-  namespace: rotsee
+  namespace: core-team
 spec:
-  version: latest
-  identityPoolName: core-rotsee
-  identityName: core-rotsee-1
+  version: saint-louis-latest
+  identityPoolName: pull-requests-rotsee
+  identityName: pull-requests-rotsee-1
+  supportedRelease: saint-louis
+  deleteDatabase: false
   enabled: true
   config: |
     hopr:
-      host:
-        address: !IPv4 0.0.0.0
-        port: 9091
-      db:
-        data: "/app/hoprd-db"
-        initialize: true
-        force_initialize: false
+      chain:
+        network: rotsee
+        provider: http://gnosis-rpc-provider.rpc-provider.svc.cluster.local:8545
       strategy:
         on_fail_continue: true
         allow_recursive: false
-        finalize_channel_closure: true
-        strategies:
-          - !Promiscuous
-            max_channels: 10
-            network_quality_threshold: 0.5
-            new_channel_stake: "1000000 HOPR"
-            minimum_node_balance: "10000000 HOPR"
-            min_network_size_samples: 20
-            enforce_max_channels: true
-          - !AutoFunding
-            funding_amount: "1000000 HOPR"
-            min_stake_threshold: "100000 HOPR"
-          - !Aggregating
-            aggregation_threshold: 1000000
-            unrealized_balance_ratio: 0.9
-            aggregation_timeout: 60
-            aggregate_on_channel_close: true
-          - !AutoRedeeming
-            redeem_only_aggregated: True
-      heartbeat:
-        variance: 2000
-        interval: 20000
-        threshold: 60000
-      network_options:
-        min_delay: 1
-        max_delay: 300
-        quality_avg_window_size: 25
-        quality_bad_threshold: 0.2
-        quality_offline_threshold: 0.5
-        quality_step: 0.1
-        ignore_timeframe: 600
-        backoff_exponent: 1.5
-        backoff_min: 2
-        backoff_max: 300
-      healthcheck:
-        enable: true
-        host: 0.0.0.0
-        port: 8080
-      transport:
-        announce_local_addresses: false
-        prefer_local_addresses: false
-      protocol:
-        ack:
-          timeout: 15
-        heartbeat:
-          timeout: 15
-        msg:
-          timeout: 15
-        ticket_aggregation:
-          timeout: 15
-      chain:
-        network: rotsee
-        announce: true
-        provider:
-        check_unrealized_balance: true
-      safe_module:
-        safe_transaction_service_provider: https://safe-transaction.prod.hoprtech.net/
-        safe_address: "0x0000000000000000000000000000000000000000"
-        module_address: "0x0000000000000000000000000000000000000000"
-    identity:
-      file: "/app/hoprd-db/.hoprd.id"
-      password: "<READCTED>"
-      private_key:
-    inbox:
-      capacity: 512
-      max_age: 900
-      excluded_tags:
-      - 0
-    api:
-      enable: true
-      auth: !Token "<READCTED>"
-      host:
-        address: !IPv4 0.0.0.0
-        port: 3001
-    test:
-      use_weak_crypto: false
+        strategies: []
+


### PR DESCRIPTION
This PR provides a mechanism to automatically remove the hoprd database when this command is executed:
`kubectl patch hoprd core-rotsee-1 -p '{"spec":{"deleteDatabase":true}}' --type=merge`

This will allow to automate the deletion of databases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new feature to trigger database deletion directly from the user interface.

- **Updates**
	- Updated the application and chart version for better tracking and compatibility.

- **Bug Fixes**
	- Enhanced the logic for creating and modifying resources to handle new configurations effectively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->