### PR TITLE
Supporting specify IPv4 address for default session host

### DIFF
--- a/.github/workflows/build-helm-cluster.yml
+++ b/.github/workflows/build-helm-cluster.yml
@@ -66,7 +66,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Lint
-        run: helm -f ./values-stage.yaml lint
+        run: helm lint -f ./values-staging.yaml .
         working-directory: 'charts/cluster-hoprd/'
 
   package:

--- a/.github/workflows/build-helm-operator.yml
+++ b/.github/workflows/build-helm-operator.yml
@@ -66,7 +66,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Lint
-        run: helm lint
+        run: helm lint -f ./values-staging.yaml .
         working-directory: 'charts/hoprd-operator/'
 
   package:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -541,7 +541,7 @@ dependencies = [
 
 [[package]]
 name = "hoprd_operator"
-version = "0.2.19"
+version = "0.2.20"
 dependencies = [
  "async-recursion",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hoprd_operator"
-version = "0.2.19"
+version = "0.2.20"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2021"
 

--- a/charts/cluster-hoprd/README.md
+++ b/charts/cluster-hoprd/README.md
@@ -24,7 +24,7 @@ This chart packages the creation of a ClusterHoprd
 | `replicas`                          | Number of instances                                                             | `1`         |
 | `version`                           | Hoprd node version to run                                                       | `2.0.2`     |
 | `enabled`                           | Running status of the nodes                                                     | `true`      |
-| `supportedRelease`                  | The kind of supported release <providence|saint-louis>                          | `""`        |
+| `supportedRelease`                  | The kind of supported release <saint-louis>                                     | `""`        |
 | `forceIdentityName`                 | Forces identity names to be set in child Hopd resources                         | `false`     |
 | `deployment`                        | Deployment spec                                                                 | `{}`        |
 | `config`                            | Custom configuration of nodes                                                   | `""`        |

--- a/charts/cluster-hoprd/README.md
+++ b/charts/cluster-hoprd/README.md
@@ -16,7 +16,6 @@ This chart packages the creation of a ClusterHoprd
 | `wallet.identityPassword`           | Password used by all identities defined bellow                                  | `""`        |
 | `wallet.hoprdApiToken`              | API Token used by all nodes of the cluster                                      | `""`        |
 | `network`                           | Hoprd Network: rotsee, dufour                                                   | `""`        |
-| `identityPool.minReadyIdentities`   | Minimum number of identites in ready state                                      | `0`         |
 | `identityPool.funding.enabled`      | Enable cron auto-funding                                                        | `false`     |
 | `identityPool.funding.schedule`     | Cron schedule to run auto-funding job.                                          | `0 1 * * 1` |
 | `identityPool.funding.nativeAmount` | Number of xDai to fund each node                                                | `0.01`      |
@@ -27,4 +26,5 @@ This chart packages the creation of a ClusterHoprd
 | `supportedRelease`                  | The kind of supported release <saint-louis>                                     | `""`        |
 | `forceIdentityName`                 | Forces identity names to be set in child Hopd resources                         | `false`     |
 | `deployment`                        | Deployment spec                                                                 | `{}`        |
+| `service.type`                      | Service Type                                                                    | `ClusterIP` |
 | `config`                            | Custom configuration of nodes                                                   | `""`        |

--- a/charts/cluster-hoprd/values.yaml
+++ b/charts/cluster-hoprd/values.yaml
@@ -79,10 +79,10 @@ forceIdentityName: false
 ##
 deployment: {}
 
-##
-## @param service Service spec
-##
-service: 
+service:
+  ##
+  ## @param service.type Service Type
+  ##
   type: "ClusterIP"
 
 

--- a/charts/cluster-hoprd/values.yaml
+++ b/charts/cluster-hoprd/values.yaml
@@ -65,7 +65,7 @@ version: 2.0.2
 enabled: true
 
 ##
-## @param supportedRelease The kind of supported release <providence|saint-louis>
+## @param supportedRelease The kind of supported release <saint-louis>
 ##
 supportedRelease: ""
 

--- a/charts/hoprd-operator/Chart.yaml
+++ b/charts/hoprd-operator/Chart.yaml
@@ -2,8 +2,8 @@
 
 apiVersion: v2
 name: hoprd-operator
-version: 0.2.16
-appVersion: 0.2.19
+version: 0.2.17
+appVersion: 0.2.20
 description: A Helm chart operator for managing Hopr nodes
 type: application
 icon: "https://hoprnet.org/assets/icons/logo.svg"

--- a/charts/hoprd-operator/templates/crd-cluster-hoprd.yaml
+++ b/charts/hoprd-operator/templates/crd-cluster-hoprd.yaml
@@ -76,7 +76,6 @@ spec:
                   type: string
                   description: 'Release Name of the supported version'
                   enum:
-                    - providence
                     - saint-louis
                 forceIdentityName:
                   type: boolean

--- a/charts/hoprd-operator/templates/crd-hoprd.yaml
+++ b/charts/hoprd-operator/templates/crd-hoprd.yaml
@@ -59,7 +59,6 @@ spec:
                   type: string
                   description: 'Release Name of the supported version'
                   enum:
-                    - providence
                     - saint-louis
                 service:
                   type: object

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -41,7 +41,6 @@ pub const HOPRD_API_TOKEN: &str = "HOPRD_API_TOKEN";
 pub const HOPRD_NETWORK: &str = "HOPRD_NETWORK";
 pub const HOPRD_CONFIGURATION_FILE_PATH: &str = "HOPRD_CONFIGURATION_FILE_PATH";
 pub const HOPRD_CONFIGURATION: &str = "HOPRD_CONFIGURATION";
-pub const HOPRD_ANNOUNCE: &str = "HOPRD_ANNOUNCE";
 pub const HOPRD_SAFE_ADDRESS: &str = "HOPRD_SAFE_ADDRESS";
 pub const HOPRD_MODULE_ADDRESS: &str = "HOPRD_MODULE_ADDRESS";
 pub const HOPRD_IDENTITY: &str = "HOPRD_IDENTITY";
@@ -49,7 +48,6 @@ pub const HOPRD_DATA: &str = "HOPRD_DATA";
 pub const HOPRD_HOST: &str = "HOPRD_HOST";
 pub const HOPRD_API: &str = "HOPRD_API";
 pub const HOPRD_API_HOST: &str = "HOPRD_API_HOST";
-pub const HOPRD_INIT: &str = "HOPRD_INIT";
 pub const HOPRD_HEALTH_CHECK: &str = "HOPRD_HEALTH_CHECK";
 pub const HOPRD_HEALTH_CHECK_HOST: &str = "HOPRD_HEALTH_CHECK_HOST";
 pub const HOPRD_SESSION_PORT_RANGE: &str = "HOPRD_SESSION_PORT_RANGE";
@@ -57,9 +55,7 @@ pub const HOPRD_PORTS_ALLOCATION: u16 = 10;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Default, Clone, Hash, Copy, JsonSchema)]
 pub enum SupportedReleaseEnum {
-    #[serde(rename = "providence")]
     #[default]
-    Providence,
     #[serde(rename = "saint-louis")]
     SaintLouis,
 }

--- a/src/hoprd/hoprd_deployment_spec.rs
+++ b/src/hoprd/hoprd_deployment_spec.rs
@@ -6,8 +6,6 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
-use crate::constants::SupportedReleaseEnum;
-
 #[derive(Serialize, Deserialize, Debug)]
 struct CustomEnvVar {
     name: String,
@@ -107,57 +105,42 @@ impl HoprdDeploymentSpec {
         }
     }
 
-    pub fn get_liveness_probe(supported_release: SupportedReleaseEnum, hoprd_deployment_spec_option: Option<HoprdDeploymentSpec>) -> Option<Probe> {
-        match supported_release {
-            SupportedReleaseEnum::Providence => None,
-            SupportedReleaseEnum::SaintLouis => {
-                let default_liveness_probe = HoprdDeploymentSpec::build_probe("/healthyz".to_owned(), Some(5), Some(1), Some(3));
-                if let Some(hoprd_deployment_spec) = hoprd_deployment_spec_option {
-                    if let Some(liveness_probe_string) = hoprd_deployment_spec.liveness_probe {
-                        Some(serde_yaml::from_str(&liveness_probe_string).unwrap())
-                    } else {
-                        Some(default_liveness_probe)
-                    }
-                } else {
-                    Some(default_liveness_probe)
-                }
+    pub fn get_liveness_probe(hoprd_deployment_spec_option: Option<HoprdDeploymentSpec>) -> Option<Probe> {
+        let default_liveness_probe = HoprdDeploymentSpec::build_probe("/healthyz".to_owned(), Some(5), Some(1), Some(3));
+        if let Some(hoprd_deployment_spec) = hoprd_deployment_spec_option {
+            if let Some(liveness_probe_string) = hoprd_deployment_spec.liveness_probe {
+                Some(serde_yaml::from_str(&liveness_probe_string).unwrap())
+            } else {
+                Some(default_liveness_probe)
             }
+        } else {
+            Some(default_liveness_probe)
         }
     }
 
-    pub fn get_startup_probe(supported_release: SupportedReleaseEnum, hoprd_deployment_spec_option: Option<HoprdDeploymentSpec>) -> Option<Probe> {
-        match supported_release {
-            SupportedReleaseEnum::Providence => None,
-            SupportedReleaseEnum::SaintLouis => {
-                let default_startup_probe = HoprdDeploymentSpec::build_probe("/startedz".to_owned(), Some(15), Some(1), Some(8));
-                if let Some(hoprd_deployment_spec) = hoprd_deployment_spec_option {
-                    if let Some(startup_probe_string) = hoprd_deployment_spec.startup_probe {
-                        Some(serde_yaml::from_str(&startup_probe_string).unwrap())
-                    } else {
-                        Some(default_startup_probe)
-                    }
-                } else {
-                    Some(default_startup_probe)
-                }
+    pub fn get_startup_probe(hoprd_deployment_spec_option: Option<HoprdDeploymentSpec>) -> Option<Probe> {
+        let default_startup_probe = HoprdDeploymentSpec::build_probe("/startedz".to_owned(), Some(15), Some(1), Some(8));
+        if let Some(hoprd_deployment_spec) = hoprd_deployment_spec_option {
+            if let Some(startup_probe_string) = hoprd_deployment_spec.startup_probe {
+                Some(serde_yaml::from_str(&startup_probe_string).unwrap())
+            } else {
+                Some(default_startup_probe)
             }
+        } else {
+            Some(default_startup_probe)
         }
     }
 
-    pub fn get_readiness_probe(supported_release: SupportedReleaseEnum, hoprd_deployment_spec_option: Option<HoprdDeploymentSpec>) -> Option<Probe> {
-        match supported_release {
-            SupportedReleaseEnum::Providence => None,
-            SupportedReleaseEnum::SaintLouis => {
-                let default_readiness_probe = HoprdDeploymentSpec::build_probe("/readyz".to_owned(), Some(10), Some(1), Some(6));
-                if let Some(hoprd_deployment_spec) = hoprd_deployment_spec_option {
-                    if let Some(readiness_probe_string) = hoprd_deployment_spec.readiness_probe {
-                        Some(serde_yaml::from_str(&readiness_probe_string).unwrap())
-                    } else {
-                        Some(default_readiness_probe)
-                    }
-                } else {
-                    Some(default_readiness_probe)
-                }
+    pub fn get_readiness_probe(hoprd_deployment_spec_option: Option<HoprdDeploymentSpec>) -> Option<Probe> {
+        let default_readiness_probe = HoprdDeploymentSpec::build_probe("/readyz".to_owned(), Some(10), Some(1), Some(6));
+        if let Some(hoprd_deployment_spec) = hoprd_deployment_spec_option {
+            if let Some(readiness_probe_string) = hoprd_deployment_spec.readiness_probe {
+                Some(serde_yaml::from_str(&readiness_probe_string).unwrap())
+            } else {
+                Some(default_readiness_probe)
             }
+        } else {
+            Some(default_readiness_probe)
         }
     }
 }


### PR DESCRIPTION
Kubernetes provides by default the IPv6 ip address of the pod. This change, forces to use the IPv4 address for the default session listen_host

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced a new property `service.type` for the `ClusterHoprd` chart, specifying the service type with a default value of `ClusterIP`.
  - Expanded options for `supportedRelease` in the `Hoprd` resource to include `saint-louis`.
  
- **Updates**
  - Updated version numbers for various components to reflect the latest changes.
  - Enhanced documentation for parameters in the `README.md` and `values.yaml` files to clarify supported release options.

- **Improvements**
  - Streamlined deployment configuration by simplifying probe definitions and enhancing environment variable handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->