### PR TITLE
env: Fix default session host ip

### DIFF
--- a/src/hoprd/hoprd_deployment_spec.rs
+++ b/src/hoprd/hoprd_deployment_spec.rs
@@ -9,8 +9,8 @@ use std::collections::BTreeMap;
 #[derive(Serialize, Deserialize, Debug, Clone)]
 struct CustomKeyRef {
     key: String,
-    name: String
-}   
+    name: String,
+}
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 struct CustomValueFrom {
@@ -18,14 +18,12 @@ struct CustomValueFrom {
 }
 
 impl CustomValueFrom {
-
     pub fn to_env_var_source(&self) -> EnvVarSource {
         EnvVarSource {
             secret_key_ref: Some(SecretKeySelector {
                 key: self.secret_key_ref.key.to_owned(),
                 name: Some(self.secret_key_ref.name.to_owned()),
                 ..SecretKeySelector::default()
-
             }),
             ..EnvVarSource::default()
         }
@@ -41,7 +39,11 @@ struct CustomEnvVar {
 
 impl CustomEnvVar {
     pub fn new_value(name: String, value: String) -> Self {
-        Self { name, value: Some(value), value_from: None }
+        Self {
+            name,
+            value: Some(value),
+            value_from: None,
+        }
     }
 
     pub fn to_env_var(&self) -> EnvVar {
@@ -120,10 +122,16 @@ impl HoprdDeploymentSpec {
         let default_environment_variables: Vec<CustomEnvVar> = serde_yaml::from_str(default_deployment_spec.env.as_ref().unwrap()).unwrap();
         let custom_environment_variables_string = hoprd_deployment_spec.env.as_ref().unwrap_or(default_deployment_spec.env.as_ref().unwrap());
         let custom_environment_variables: Vec<CustomEnvVar> = serde_yaml::from_str(custom_environment_variables_string).unwrap();
-        default_environment_variables.iter().filter(| &default_environment_variable| {
-            !custom_environment_variables.iter().any(|custom_environment_variable| custom_environment_variable.name == default_environment_variable.name)
-        }).chain(custom_environment_variables.iter()).map(|env| env.to_env_var()).collect()
-
+        default_environment_variables
+            .iter()
+            .filter(|&default_environment_variable| {
+                !custom_environment_variables
+                    .iter()
+                    .any(|custom_environment_variable| custom_environment_variable.name == default_environment_variable.name)
+            })
+            .chain(custom_environment_variables.iter())
+            .map(|env| env.to_env_var())
+            .collect()
     }
 
     pub fn build_probe(path: String, period_seconds: Option<i32>, success_threshold: Option<i32>, failure_threshold: Option<i32>) -> Probe {

--- a/src/identity_pool/identity_pool_cronjob_faucet.rs
+++ b/src/identity_pool/identity_pool_cronjob_faucet.rs
@@ -58,7 +58,10 @@ pub async fn create_cron_job(context_data: Arc<ContextData>, identity_pool: &Ide
 async fn build_args_line(identity_pool: &IdentityPool) -> Option<Vec<String>> {
     let native_amount: String = identity_pool.spec.funding.clone().unwrap().native_amount.to_string();
     let network: String = identity_pool.spec.network.to_owned();
-    let command_line: String = format!("PATH=${{PATH}}:/app/hoprnet/.foundry/bin/ /bin/hopli faucet --provider-url https://gnosis.drpc.org --network {} --hopr-amount 0 --native-amount \"{}\" --address $(cat /data/addresses.txt)", network, native_amount);
+    let command_line: String = format!(
+        "PATH=${{PATH}}:/app/hoprnet/.foundry/bin/ /bin/hopli faucet --provider-url https://gnosis.drpc.org --network {} --hopr-amount 0 --native-amount \"{}\" --address $(cat /data/addresses.txt)",
+        network, native_amount
+    );
     Some(vec![command_line])
 }
 

--- a/src/identity_pool/identity_pool_service_monitor.rs
+++ b/src/identity_pool/identity_pool_service_monitor.rs
@@ -10,8 +10,7 @@ use tracing::info;
 
 use crate::context_data::ContextData;
 use crate::servicemonitor::{
-    ServiceMonitorEndpoints, ServiceMonitorEndpointsRelabelings, ServiceMonitorEndpointsRelabelingsAction, ServiceMonitorNamespaceSelector,
-    ServiceMonitorSelector, ServiceMonitorSpec,
+    ServiceMonitorEndpoints, ServiceMonitorEndpointsRelabelings, ServiceMonitorEndpointsRelabelingsAction, ServiceMonitorNamespaceSelector, ServiceMonitorSelector, ServiceMonitorSpec,
 };
 use crate::{constants, servicemonitor::ServiceMonitor};
 


### PR DESCRIPTION
The default session host must be the pod IP, otherwise hoprd will not bind to the correct IP specifically for UDP. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved formatting and readability across deployment and environment variable configuration, including restructuring imports and reformatting code blocks.
  - Adjusted how environment variables related to host and ports are constructed and passed, including the addition of a new environment variable for session listen host.
- **Style**
  - Enhanced code consistency with unified indentation, spacing, and multi-line formatting in several components. 

No changes to user-facing functionality or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->