### PR TITLE
Add Kaunas supported release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -541,7 +541,7 @@ dependencies = [
 
 [[package]]
 name = "hoprd_operator"
-version = "0.2.29"
+version = "0.2.30"
 dependencies = [
  "async-recursion",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hoprd_operator"
-version = "0.2.29"
+version = "0.2.30"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2021"
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ spec:
   forceIdentityName: true
   identityPoolName: hoprd-core-rotsee
   replicas: 5
-  supportedRelease: saint-louis
+  supportedRelease: kaunas
   version: 2.1.0
 status:
   currentNodes: 5
@@ -143,7 +143,7 @@ spec:
   enabled: true
   identityName: hoprd-core-rotsee-1
   identityPoolName: hoprd-core-rotsee
-  supportedRelease: saint-louis
+  supportedRelease: kaunas
   version: 2.1.0
 status:
   identityName: hoprd-core-rotsee-1

--- a/charts/cluster-hoprd/Chart.yaml
+++ b/charts/cluster-hoprd/Chart.yaml
@@ -2,7 +2,7 @@
 
 apiVersion: v2
 name: cluster-hoprd
-version: 0.3.7
+version: 0.3.8
 description: A Helm chart to deploy ClusterHoprd
 type: application
 icon: "https://hoprnet.org/assets/icons/logo.svg"

--- a/charts/cluster-hoprd/README.md
+++ b/charts/cluster-hoprd/README.md
@@ -23,7 +23,7 @@ This chart packages the creation of a ClusterHoprd
 | `replicas`                          | Number of instances                                                             | `1`         |
 | `version`                           | Hoprd node version to run                                                       | `2.0.2`     |
 | `enabled`                           | Running status of the nodes                                                     | `true`      |
-| `supportedRelease`                  | The kind of supported release <saint-louis>                                     | `""`        |
+| `supportedRelease`                  | The kind of supported release <kaunas>                                          | `""`        |
 | `forceIdentityName`                 | Forces identity names to be set in child Hopd resources                         | `false`     |
 | `deployment`                        | Deployment spec                                                                 | `{}`        |
 | `service.type`                      | Service Type                                                                    | `ClusterIP` |

--- a/charts/cluster-hoprd/README.md
+++ b/charts/cluster-hoprd/README.md
@@ -9,22 +9,25 @@ This chart packages the creation of a ClusterHoprd
 
 ### Common parameters
 
-| Name                                | Description                                                                     | Value       |
-| ----------------------------------- | ------------------------------------------------------------------------------- | ----------- |
-| `nameOverride`                      | String to partially override common.names.fullname                              | `""`        |
-| `wallet.deployerPrivateKey`         | The staking wallet private key used to create identities and to auto fund nodes | `""`        |
-| `wallet.identityPassword`           | Password used by all identities defined bellow                                  | `""`        |
-| `wallet.hoprdApiToken`              | API Token used by all nodes of the cluster                                      | `""`        |
-| `network`                           | Hoprd Network: rotsee, dufour                                                   | `""`        |
-| `identityPool.funding.enabled`      | Enable cron auto-funding                                                        | `false`     |
-| `identityPool.funding.schedule`     | Cron schedule to run auto-funding job.                                          | `0 1 * * 1` |
-| `identityPool.funding.nativeAmount` | Number of xDai to fund each node                                                | `0.01`      |
-| `identities`                        | Map of identities to create                                                     | `{}`        |
-| `replicas`                          | Number of instances                                                             | `1`         |
-| `version`                           | Hoprd node version to run                                                       | `2.0.2`     |
-| `enabled`                           | Running status of the nodes                                                     | `true`      |
-| `supportedRelease`                  | The kind of supported release <kaunas>                                          | `""`        |
-| `forceIdentityName`                 | Forces identity names to be set in child Hopd resources                         | `false`     |
-| `deployment`                        | Deployment spec                                                                 | `{}`        |
-| `service.type`                      | Service Type                                                                    | `ClusterIP` |
-| `config`                            | Custom configuration of nodes                                                   | `""`        |
+| Name                                 | Description                                                                     | Value                     |
+| ------------------------------------ | ------------------------------------------------------------------------------- | ------------------------- |
+| `nameOverride`                       | String to partially override common.names.fullname                              | `""`                      |
+| `wallet.deployerPrivateKey`          | The staking wallet private key used to create identities and to auto fund nodes | `""`                      |
+| `wallet.identityPassword`            | Password used by all identities defined bellow                                  | `""`                      |
+| `wallet.hoprdApiToken`               | API Token used by all nodes of the cluster                                      | `""`                      |
+| `network`                            | Hoprd Network: rotsee, dufour                                                   | `""`                      |
+| `identityPool.funding.enabled`       | Enable cron auto-funding                                                        | `false`                   |
+| `identityPool.funding.schedule`      | Cron schedule to run auto-funding job.                                          | `0 1 * * 1`               |
+| `identityPool.funding.nativeAmount`  | Number of xDai to fund each node                                                | `0.01`                    |
+| `identities`                         | Map of identities to create                                                     | `{}`                      |
+| `replicas`                           | Number of instances                                                             | `1`                       |
+| `version`                            | Hoprd node version to run                                                       | `""`                      |
+| `enabled`                            | Running status of the nodes                                                     | `true`                    |
+| `supportedRelease`                   | The kind of supported release <saint-louis>                                     | `""`                      |
+| `forceIdentityName`                  | Forces identity names to be set in child Hopd resources                         | `false`                   |
+| `deployment`                         | Deployment spec                                                                 | `{}`                      |
+| `portsAllocation`                    | Ports allocation                                                                | `10`                      |
+| `service.type`                       | Service Type                                                                    | `ClusterIP`               |
+| `config`                             | Custom configuration of nodes                                                   | `""`                      |
+| `replicateDefaultEnvSecret.enabled`  | Enable secret replication                                                       | `true`                    |
+| `defaultHoprdEnvVars.HOPRD_PROVIDER` | RPC Provider to use by default to all hoprd nodes                               | `https://gnosis.drpc.org` |

--- a/charts/cluster-hoprd/templates/cluster-hoprd.yaml
+++ b/charts/cluster-hoprd/templates/cluster-hoprd.yaml
@@ -11,7 +11,7 @@ spec:
   replicas: {{ .Values.replicas }}
   version: {{ .Values.version | quote }}
   enabled: {{ .Values.enabled | default true }}
-  supportedRelease: {{ .Values.supportedRelease | default "saint-louis" }}
+  supportedRelease: {{ .Values.supportedRelease | default "kaunas" }}
   forceIdentityName: {{ .Values.forceIdentityName | default true }}
   {{- if .Values.deployment }}
   deployment: {{ .Values.deployment | toYaml | nindent 4 }}

--- a/charts/cluster-hoprd/values.yaml
+++ b/charts/cluster-hoprd/values.yaml
@@ -80,7 +80,7 @@ forceIdentityName: false
 deployment: {}
 
 ##
-## @param ports_allocation Ports allocation
+## @param portsAllocation Ports allocation
 ##
 portsAllocation: 10
 
@@ -98,13 +98,13 @@ config: ""
 
 replicateDefaultEnvSecret:
   ##
-  ## @param replicateSecret.enabled Enable secret replication
+  ## @param replicateDefaultEnvSecret.enabled Enable secret replication
   ##
   enabled: true
 
 
-##
-## @param defaultHoprdEnvVars Default environment variables for hoprd
-##
 defaultHoprdEnvVars:
+  ##
+  ## @param defaultHoprdEnvVars.HOPRD_PROVIDER RPC Provider to use by default to all hoprd nodes
+  ##
   HOPRD_PROVIDER: https://gnosis.drpc.org

--- a/charts/hoprd-operator/Chart.yaml
+++ b/charts/hoprd-operator/Chart.yaml
@@ -2,8 +2,8 @@
 
 apiVersion: v2
 name: hoprd-operator
-version: 0.2.25
-appVersion: 0.2.27
+version: 0.2.26
+appVersion: 0.2.30
 description: A Helm chart operator for managing Hopr nodes
 type: application
 icon: "https://hoprnet.org/assets/icons/logo.svg"

--- a/charts/hoprd-operator/README.md
+++ b/charts/hoprd-operator/README.md
@@ -49,7 +49,7 @@ Chart version `Chart.yaml` should be increased according to [semver](http://semv
 | `adminUI.affinity`                 | Affinity specifications to AdminUI deployment                                                         | `{}`                                       |
 | `adminUI.image.registry`           | Docker registry to AdminUI deployment                                                                 | `europe-west3-docker.pkg.dev`              |
 | `adminUI.image.repository`         | Docker image repository to AdminUI deployment                                                         | `hoprassociation/docker-images/hopr-admin` |
-| `adminUI.image.tag`                | Docker image tag to AdminUI deployment                                                                | `latest`                                   |
+| `adminUI.image.tag`                | Docker image tag to AdminUI deployment                                                                | `stable`                                   |
 | `adminUI.image.pullPolicy`         | Pull policy to AdminUI deployment as deinfed in                                                       | `Always`                                   |
 | `adminUI.ingress.enabled`          | Enable ingress record generation                                                                      | `true`                                     |
 | `adminUI.ingress.pathType`         | Ingress path type                                                                                     | `ImplementationSpecific`                   |

--- a/charts/hoprd-operator/templates/crd-cluster-hoprd.yaml
+++ b/charts/hoprd-operator/templates/crd-cluster-hoprd.yaml
@@ -77,6 +77,7 @@ spec:
                   description: 'Release Name of the supported version'
                   enum:
                     - saint-louis
+                    - kaunas
                 forceIdentityName:
                   type: boolean
                   description: Flag indicating whether the identityName should be specified in child Hoprd

--- a/charts/hoprd-operator/templates/crd-hoprd.yaml
+++ b/charts/hoprd-operator/templates/crd-hoprd.yaml
@@ -60,6 +60,7 @@ spec:
                   description: 'Release Name of the supported version'
                   enum:
                     - saint-louis
+                    - kaunas
                 service:
                   type: object
                   description: Service configuration

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,3 +1,5 @@
+use std::fmt::{Display, Formatter};
+
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -61,4 +63,16 @@ pub enum SupportedReleaseEnum {
     #[default]
     #[serde(rename = "saint-louis")]
     SaintLouis,
+    #[serde(rename = "kaunas")]
+    Kaunas,
+}
+
+impl Display for SupportedReleaseEnum {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        match self {
+            SupportedReleaseEnum::SaintLouis => write!(f, "saint-louis"),
+            SupportedReleaseEnum::Kaunas => write!(f, "kaunas"),
+
+        }
+    }
 }

--- a/src/hoprd/hoprd_deployment.rs
+++ b/src/hoprd/hoprd_deployment.rs
@@ -1,3 +1,4 @@
+use crate::constants::SupportedReleaseEnum;
 use crate::hoprd::hoprd_deployment_spec::HoprdDeploymentSpec;
 use crate::identity_hoprd::identity_hoprd_resource::IdentityHoprd;
 use crate::identity_pool::identity_pool_resource::IdentityPool;
@@ -174,7 +175,7 @@ pub async fn build_deployment_spec(
                     volume_mounts,
                     resources,
                     ..Container::default()
-                }, metrics_container(&identity_pool)],
+                }, metrics_container(&identity_pool, &hoprd_spec.supported_release.clone())],
                 volumes: Some(build_volumes(&identity_hoprd.name_any()).await),
                 ..PodSpec::default()
             }),
@@ -223,11 +224,12 @@ pub async fn modify_deployment(context_data: Arc<ContextData>, deployment_name: 
     Ok(())
 }
 
-pub fn metrics_container(identity_pool: &IdentityPool) -> Container {
-    let image = format!(
-        "{}/{}:latest",
+pub fn metrics_container(identity_pool: &IdentityPool, supported_release: &SupportedReleaseEnum) -> Container {
+    let image: String = format!(
+        "{}/{}:{}",
         constants::HOPR_DOCKER_REGISTRY.to_owned(),
-        constants::HOPR_DOCKER_METRICS_IMAGE_NAME.to_owned()
+        constants::HOPR_DOCKER_METRICS_IMAGE_NAME.to_owned(),
+        supported_release.to_string()
     );
     Container {
         name: "hoprd-operator-metrics".to_owned(),

--- a/test-data/cluster-hoprd.yaml
+++ b/test-data/cluster-hoprd.yaml
@@ -10,7 +10,7 @@ spec:
   identityPoolName: pull-requests-rotsee
   replicas: 1
   version: singapore-latest
-  supportedRelease: saint-louis
+  supportedRelease: kaunas
   enabled: true
   service:
     type: LoadBalancer

--- a/test-data/hoprd-node-core.yaml
+++ b/test-data/hoprd-node-core.yaml
@@ -8,7 +8,7 @@ spec:
   version: saint-louis-latest
   identityPoolName: pull-requests-rotsee
   identityName: pull-requests-rotsee-1
-  supportedRelease: saint-louis
+  supportedRelease: kaunas
   deleteDatabase: false
   service:
     type: LoadBalancer


### PR DESCRIPTION
Add support for Kaunas release and allow metrics to work with saint-louis and Kaunas

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the "kaunas" release across resource specifications and configuration options.
  * Expanded enum values to allow "kaunas" for the supportedRelease field in both ClusterHoprd and Hoprd resources.

* **Documentation**
  * Updated documentation and example configurations to reference "kaunas" as the supported release.
  * Improved and expanded parameter documentation in Helm chart READMEs and values files.
  * Changed the default Docker image tag for AdminUI from "latest" to "stable".

* **Bug Fixes**
  * Corrected parameter names and descriptions in configuration comments for improved clarity.

* **Chores**
  * Incremented version numbers for packages and Helm charts to reflect the latest changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->