### PR TITLE
Make portsAllocation compulsory

### DIFF
--- a/charts/hoprd-operator/templates/crd-cluster-hoprd.yaml
+++ b/charts/hoprd-operator/templates/crd-cluster-hoprd.yaml
@@ -121,7 +121,7 @@ spec:
                     Number of ports to be opened for session management in the hoprd node.
                     Each session requires one port. Default: 10 ports if not specified.
                     Warning: Large numbers may impact kubernetes cluster performance.
-                  minimum: 1
+                  minimum: 0
                   maximum: 200
                 sourceNodeLogs:
                   type: string
@@ -132,6 +132,7 @@ spec:
                 - config
                 - version
                 - supportedRelease
+                - portsAllocation
             status:
               description: The status object of ClusterHord node
               nullable: true

--- a/charts/hoprd-operator/templates/crd-hoprd.yaml
+++ b/charts/hoprd-operator/templates/crd-hoprd.yaml
@@ -116,12 +116,13 @@ spec:
                     Number of ports to be opened for session management in the hoprd node.
                     Each session requires one port. Default: 10 ports if not specified.
                     Warning: Large numbers may impact kubernetes cluster performance.
-                  minimum: 1
+                  minimum: 0
                   maximum: 200
               required: 
                 - version
                 - identityPoolName
                 - supportedRelease
+                - portsAllocation
             status:
               description: The status object of Hoprd node
               nullable: true

--- a/src/cluster/cluster_hoprd.rs
+++ b/src/cluster/cluster_hoprd.rs
@@ -50,7 +50,7 @@ pub struct ClusterHoprdSpec {
     pub service: Option<HoprdServiceSpec>,
     pub deployment: Option<HoprdDeploymentSpec>,
     #[schemars(range(min = 1024, max = 65535))]
-    pub ports_allocation: Option<u16>,
+    pub ports_allocation: u16,
     pub source_node_logs: Option<String>,
 }
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -46,7 +46,6 @@ pub const HOPRD_MODULE_ADDRESS: &str = "HOPRD_MODULE_ADDRESS";
 pub const HOPRD_HOST: &str = "HOPRD_HOST";
 pub const HOPRD_API: &str = "HOPRD_API";
 pub const HOPRD_SESSION_PORT_RANGE: &str = "HOPRD_SESSION_PORT_RANGE";
-pub const HOPRD_PORTS_ALLOCATION: u16 = 10;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Default, Clone, Hash, Copy, JsonSchema)]
 pub enum SupportedReleaseEnum {


### PR DESCRIPTION
By default it was assigning HOPRD_SESSION_PORT_RANGE to 10, now the attribute `portsAllocation` is compulsory but it accepts the value 0, which means unsetting the env var.